### PR TITLE
Add more declarative validator logic; remove all logic from the API functions.

### DIFF
--- a/lib/apis/directions.js
+++ b/lib/apis/directions.js
@@ -4,38 +4,38 @@ var v = require('../validate');
 
 var path = '/maps/api/directions/json';
 
-var validateDirectionsQuery = v.object({
-  alternatives: v.optional(v.boolean),
-  arrival_time: v.optional(utils.timeStamp),
-  avoid: v.optional(utils.pipedArrayOf(v.oneOf([
-    'tolls', 'highways', 'ferries', 'indoor'
-  ]))),
-  departure_time: v.optional(utils.timeStamp),
-  destination: utils.latLng,
-  mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
-  optimize: v.optional(v.boolean),
-  origin: utils.latLng,
-  retryOptions: v.optional(utils.retryOptions),
-  units: v.optional(v.oneOf(['metric', 'imperial'])),
-  waypoints: v.optional(utils.pipedArrayOf(utils.latLng))
-});
+var validateDirectionsQuery = v.compose([
+  v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
+  v.object({
+    alternatives: v.optional(v.boolean),
+    arrival_time: v.optional(utils.timeStamp),
+    avoid: v.optional(utils.pipedArrayOf(v.oneOf([
+      'tolls', 'highways', 'ferries', 'indoor'
+    ]))),
+    departure_time: v.optional(utils.timeStamp),
+    destination: utils.latLng,
+    mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
+    optimize: v.optional(v.boolean),
+    origin: utils.latLng,
+    retryOptions: v.optional(utils.retryOptions),
+    units: v.optional(v.oneOf(['metric', 'imperial'])),
+    waypoints: v.optional(utils.pipedArrayOf(utils.latLng))
+  }),
+  function(query) {
+    if (query.waypoints && query.optimize) {
+      query.waypoints = 'optimize:true|' + query.waypoints;
+    }
+    delete query.optimize;
+
+    return query;
+  }
+]);
 
 exports.inject = function(makeApiCall) {
   return {
 
     directions: function(query, callback) {
       query = validateDirectionsQuery(query);
-
-      if (query.departure_time && query.arrival_time) {
-        throw new InvalidValueError(
-            'should not specify both departure_time and arrival_time');
-      }
-
-      if (query.waypoints && query.optimize) {
-        query.waypoints = 'optimize:true|' + query.waypoints;
-      }
-      delete query.optimize;
-
       return makeApiCall(path, query, callback);
     }
 

--- a/lib/apis/distance-matrix.js
+++ b/lib/apis/distance-matrix.js
@@ -4,33 +4,29 @@ var v = require('../validate');
 
 var path = '/maps/api/distancematrix/json';
 
-var validateDistanceMatrixQuery = v.object({
-  arrival_time: v.optional(utils.timeStamp),
-  avoid: v.optional(utils.pipedArrayOf(v.oneOf([
-    'tolls', 'highways', 'ferries', 'indoor'
-  ]))),
-  departure_time: v.optional(utils.timeStamp),
-  destinations: utils.pipedArrayOf(utils.latLng),
-  mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
-  retryOptions: v.optional(utils.retryOptions),
-  transit_mode: v.optional(utils.pipedArrayOf(v.oneOf[
-    'bus', 'subway', 'train', 'tram', 'rail'
-  ])),
-  origins: utils.pipedArrayOf(utils.latLng)
-});
+var validateDistanceMatrixQuery = v.compose([
+  v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
+  v.object({
+    arrival_time: v.optional(utils.timeStamp),
+    avoid: v.optional(utils.pipedArrayOf(v.oneOf([
+      'tolls', 'highways', 'ferries', 'indoor'
+    ]))),
+    departure_time: v.optional(utils.timeStamp),
+    destinations: utils.pipedArrayOf(utils.latLng),
+    mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
+    retryOptions: v.optional(utils.retryOptions),
+    transit_mode: v.optional(utils.pipedArrayOf(v.oneOf[
+      'bus', 'subway', 'train', 'tram', 'rail'
+    ])),
+    origins: utils.pipedArrayOf(utils.latLng)
+  })
+]);
 
 exports.inject = function(makeApiCall) {
   return {
 
     distanceMatrix: function(query, callback) {
-
       query = validateDistanceMatrixQuery(query);
-
-      if (query.departure_time && query.arrival_time) {
-        throw new InvalidValueError(
-            'should not specify both departure_time and arrival_time');
-      }
-
       return makeApiCall(path, query, callback);
     }
 

--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -4,40 +4,39 @@ var v = require('../validate');
 
 var path = '/maps/api/geocode/json';
 
-var validateGeocodeQuery = v.object({
-  address: v.optional(v.string),
-  bounds: v.optional(utils.bounds),
-  components: v.optional(utils.pipedKeyValues),
-  retryOptions: v.optional(utils.retryOptions)
-});
+var validateGeocodeQuery = v.compose([
+  v.mutuallyExclusiveProperties(['address', 'components']),
+  v.object({
+    address: v.optional(v.string),
+    bounds: v.optional(utils.bounds),
+    components: v.optional(utils.pipedKeyValues),
+    retryOptions: v.optional(utils.retryOptions)
+  })
+]);
 
-var validateReverseGeocodeQuery = v.object({
-  latlng: v.optional(utils.latLng),
-  location_type: v.optional(utils.pipedArrayOf(v.oneOf([
-    'ROOFTOP', 'RANGE_INTERPOLATED', 'GEOMETRIC_CENTER', 'APPROXIMATE'
-  ]))),
-  place_id: v.optional(v.string),
-  result_type: v.optional(utils.pipedArrayOf(v.string)),
-  retryOptions: v.optional(utils.retryOptions)
-});
+var validateReverseGeocodeQuery = v.compose([
+  v.mutuallyExclusiveProperties(['latlng', 'place_id']),
+  v.object({
+    latlng: v.optional(utils.latLng),
+    location_type: v.optional(utils.pipedArrayOf(v.oneOf([
+      'ROOFTOP', 'RANGE_INTERPOLATED', 'GEOMETRIC_CENTER', 'APPROXIMATE'
+    ]))),
+    place_id: v.optional(v.string),
+    result_type: v.optional(utils.pipedArrayOf(v.string)),
+    retryOptions: v.optional(utils.retryOptions)
+  })
+]);
 
 exports.inject = function(makeApiCall) {
   return {
 
     geocode: function(query, callback) {
       query = validateGeocodeQuery(query);
-      if (query.address && query.components) {
-        throw new InvalidValueError(
-            'cannot specify both address and components');
-      }
       return makeApiCall(path, query, callback);
     },
 
     reverseGeocode: function(query, callback) {
       query = validateReverseGeocodeQuery(query);
-      if (query.latlng && query.place_id) {
-        throw new InvalidValueError('cannot specify both latlng and place_id');
-      }
       return makeApiCall(path, query, callback);
     }
 

--- a/lib/apis/timezone.js
+++ b/lib/apis/timezone.js
@@ -13,7 +13,8 @@ exports.inject = function(makeApiCall) {
   return {
 
     timezone: function(query, callback) {
-      return makeApiCall(path, validateTimezoneQuery(query), callback);
+      query = validateTimezoneQuery(query);
+      return makeApiCall(path, query, callback);
     }
 
   };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -100,3 +100,36 @@ Validate.oneOf = function(names) {
     throw new InvalidValueError('not one of ' + quotedNames.join(', '));
   };
 };
+
+Validate.mutuallyExclusiveProperties = function(names) {
+  return function(value) {
+    if (!value) return value;
+
+    var present = [];
+    names.forEach(function(name) {
+      if (name in value) {
+        present.push('"' + name + '"');
+      }
+    });
+
+    if (present.length > 1) {
+      throw new InvalidValueError(
+          'cannot specify properties '
+          + present.slice(0, -1).join(', ')
+          + ' and '
+          + present.slice(-1)
+          + ' together');
+    }
+
+    return value;
+  };
+};
+
+Validate.compose = function(validators) {
+  return function(value) {
+    validators.forEach(function(validate) {
+      value = validate(value);
+    });
+    return value;
+  };
+};

--- a/spec/validate-spec.js
+++ b/spec/validate-spec.js
@@ -85,4 +85,28 @@ describe('Validate', function() {
     });
   });
 
+  describe('.mutuallyExclusiveProperties', function() {
+    var validate = Validate.mutuallyExclusiveProperties(['one', 'two', 'four']);
+
+    it('accepts objects with none of the properties', function() {
+      expect(validate({a: 1})).toEqual({a: 1});
+    });
+
+    it('accepts objects with exactly one of the properties', function() {
+      expect(validate({one: 1, three: 3})).toEqual({one: 1, three: 3});
+    });
+
+    it('rejects objects with two of the properties', function() {
+      expect(function() {
+        validate({one: 1, four: 4});
+      }).toThrowError(InvalidValueError, /"one" and "four"/);
+    });
+
+    it('rejects objects with more than two of the properties', function() {
+      expect(function() {
+        validate({one: 1, two: 2, four: 4});
+      }).toThrowError(InvalidValueError, /"one", "two" and "four"/);
+    });
+  });
+
 });


### PR DESCRIPTION
This makes the API functions consistently of the form:

```
endpointName: function(query, callback) {
  query = endpointValidator(query);
  return makeApiCall(path, query, callback);
}
```
