### PR TITLE
Convert remaining API handlers to new validation util.

### DIFF
--- a/lib/apis/distance-matrix.js
+++ b/lib/apis/distance-matrix.js
@@ -1,4 +1,3 @@
-var InvalidValueError = require('../invalid-value-error');
 var utils = require('../utils');
 var v = require('../validate');
 

--- a/lib/apis/elevation.js
+++ b/lib/apis/elevation.js
@@ -1,25 +1,35 @@
 var utils = require('../utils');
+var v = require('../validate');
+
+var validateElevationQuery = v.object({
+  locations: utils.pipedArrayOf(utils.latLng)
+});
+
+var validateElevationAlongPathQuery = v.compose([
+  v.object({
+    path: v.either([v.array(utils.latLng), v.string]),
+    samples: v.number
+  }),
+  function(query) {
+    if (typeof query.path == 'string') {
+      query.path = 'enc:' + query.path;
+    } else {
+      query.path = utils.pipedArrayOf(utils.latLng)(query.path);
+    }
+    return query;
+  }
+]);
 
 exports.inject = function(url, makeApiCall) {
   return {
 
     elevation: function(query, callback) {
-      if (!query.locations) {
-        throw 'locations param required';
-      }
-      query.locations = utils.locations(query.locations);
+      query = validateElevationQuery(query);
       return makeApiCall(url, query, callback);
     },
 
     elevationAlongPath: function(query, callback) {
-      if (!query.path || !query.samples) {
-        throw 'path and samples params required';
-      }
-      if (typeof query.path == 'string') {
-        query.path = 'enc:' + query.path;
-      } else {
-        query.path = utils.locations(query.path);
-      }
+      query = validateElevationAlongPathQuery(query);
       return makeApiCall(url, query, callback);
     }
 

--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -1,4 +1,3 @@
-var InvalidValueError = require('../invalid-value-error');
 var utils = require('../utils');
 var v = require('../validate');
 

--- a/lib/apis/roads.js
+++ b/lib/apis/roads.js
@@ -1,31 +1,35 @@
 var utils = require('../utils');
+var v = require('../validate');
+
+var validateSnapToRoadsQuery = v.object({
+  path: utils.pipedArrayOf(utils.latLng),
+  interpolate: v.optional(v.boolean)
+});
+
+var validateSpeedLimitsQuery = v.object({
+  placeId: v.array(v.string),
+  interpolate: v.optional(v.boolean)
+});
+
+var validateSnappedSpeedLimitsQuery = v.object({
+  path: utils.pipedArrayOf(utils.latLng)
+});
 
 exports.inject = function(url, makeApiCall) {
   return {
 
     snapToRoads: function(query, callback) {
-      if (!query.path) {
-        throw 'path param required';
-      }
-      query.path = utils.locations(query.path);
-      if (query.interpolate != undefined) {
-        query.interpolate = String(!!query.interpolate);
-      }
+      query = validateSnapToRoadsQuery(query);
       return makeApiCall(url + 'snapToRoads', query, callback);
     },
 
     speedLimits: function(query, callback) {
-      if (!query.placeId) {
-        throw 'placeId param required';
-      }
+      query = validateSpeedLimitsQuery(query);
       return makeApiCall(url + 'speedLimits', query, callback);
     },
 
     snappedSpeedLimits: function(query, callback) {
-      if (!query.path) {
-        throw 'path param required';
-      }
-      query.path = utils.locations(query.path);
+      query = validateSnappedSpeedLimitsQuery(query);
       return makeApiCall(url + 'speedLimits', query, callback);
     }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -31,6 +31,20 @@ Validate.string = Validate.that(function(value) {
   return typeof value === 'string';
 }, 'not a string');
 
+Validate.either = function(validators) {
+  var errors = [];
+  return function(value) {
+    for (var i = 0; i < validators.length; ++i) {
+      try {
+        return validators[i](value);
+      } catch (error) {
+        errors[errors.length] = error.message;
+      }
+    }
+    throw new InvalidValueError('Couldn\'t validate either of: ' + errors.join(', '));
+  };
+};
+
 Validate.object = function(propertyValidators) {
   return function(object) {
     var result = {};

--- a/spec/e2e/elevation-spec.js
+++ b/spec/e2e/elevation-spec.js
@@ -6,7 +6,7 @@ describe('elevation client library', function() {
 
   it('gets the elevation for the Sydney Opera House', function(done) {
     googleMaps.elevation({
-      locations: [-33.8571965, 151.2151398]
+      locations: {lat: -33.8571965, lng: 151.2151398}
     }, function(err, response) {
       expect(err).toBe(null);
       expect(response.json.results).toEqual(

--- a/spec/validate-spec.js
+++ b/spec/validate-spec.js
@@ -85,6 +85,21 @@ describe('Validate', function() {
     });
   });
 
+  describe('.either', function() {
+    var validate = Validate.either([Validate.string, Validate.number]);
+
+    it('accepts the valid values', function() {
+      expect(validate('one')).toBe('one');
+      expect(validate(2)).toBe(2);
+    });
+
+    it('rejects other values', function() {
+      expect(function() {
+        validate(true);
+      }).toThrowError(InvalidValueError);
+    });
+  });
+
   describe('.mutuallyExclusiveProperties', function() {
     var validate = Validate.mutuallyExclusiveProperties(['one', 'two', 'four']);
 


### PR DESCRIPTION
Put this into a PR because I had to extend the validation lib a bit and wasn't sure if I was doing it correctly in spirit. :-)

I've added `Validate.either` so that we can support args that can be provided in more than one format, eg  the elevation API accepts a path param which can be a piped array of locations, or a polyline encoded string.
