### PR TITLE
Converts each of the API modules from boilerplate methods into config.

### DIFF
--- a/lib/apis/directions.js
+++ b/lib/apis/directions.js
@@ -1,40 +1,31 @@
 var utils = require('../utils');
-var InvalidValueError = require('../invalid-value-error');
 var v = require('../validate');
 
-var validateDirectionsQuery = v.compose([
-  v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
-  v.object({
-    alternatives: v.optional(v.boolean),
-    arrival_time: v.optional(utils.timeStamp),
-    avoid: v.optional(utils.pipedArrayOf(v.oneOf([
-      'tolls', 'highways', 'ferries', 'indoor'
-    ]))),
-    departure_time: v.optional(utils.timeStamp),
-    destination: utils.latLng,
-    mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
-    optimize: v.optional(v.boolean),
-    origin: utils.latLng,
-    retryOptions: v.optional(utils.retryOptions),
-    units: v.optional(v.oneOf(['metric', 'imperial'])),
-    waypoints: v.optional(utils.pipedArrayOf(utils.latLng))
-  }),
-  function(query) {
-    if (query.waypoints && query.optimize) {
-      query.waypoints = 'optimize:true|' + query.waypoints;
+exports.directions = {
+  url: 'https://maps.googleapis.com/maps/api/directions/json',
+  validator: v.compose([
+    v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
+    v.object({
+      alternatives: v.optional(v.boolean),
+      arrival_time: v.optional(utils.timeStamp),
+      avoid: v.optional(utils.pipedArrayOf(v.oneOf([
+        'tolls', 'highways', 'ferries', 'indoor'
+      ]))),
+      departure_time: v.optional(utils.timeStamp),
+      destination: utils.latLng,
+      mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
+      optimize: v.optional(v.boolean),
+      origin: utils.latLng,
+      retryOptions: v.optional(utils.retryOptions),
+      units: v.optional(v.oneOf(['metric', 'imperial'])),
+      waypoints: v.optional(utils.pipedArrayOf(utils.latLng))
+    }),
+    function(query) {
+      if (query.waypoints && query.optimize) {
+        query.waypoints = 'optimize:true|' + query.waypoints;
+      }
+      delete query.optimize;
+      return query;
     }
-    delete query.optimize;
-    return query;
-  }
-]);
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    directions: function(query, callback) {
-      query = validateDirectionsQuery(query);
-      return makeApiCall(url, query, callback);
-    }
-
-  };
+  ])
 };

--- a/lib/apis/distance-matrix.js
+++ b/lib/apis/distance-matrix.js
@@ -1,31 +1,23 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validateDistanceMatrixQuery = v.compose([
-  v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
-  v.object({
-    arrival_time: v.optional(utils.timeStamp),
-    avoid: v.optional(utils.pipedArrayOf(v.oneOf([
-      'tolls', 'highways', 'ferries', 'indoor'
-    ]))),
-    departure_time: v.optional(utils.timeStamp),
-    destinations: utils.pipedArrayOf(utils.latLng),
-    mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
-    retryOptions: v.optional(utils.retryOptions),
-    transit_mode: v.optional(utils.pipedArrayOf(v.oneOf[
-      'bus', 'subway', 'train', 'tram', 'rail'
-    ])),
-    origins: utils.pipedArrayOf(utils.latLng)
-  })
-]);
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    distanceMatrix: function(query, callback) {
-      query = validateDistanceMatrixQuery(query);
-      return makeApiCall(url, query, callback);
-    }
-
-  };
+exports.distanceMatrix = {
+  url: 'https://maps.googleapis.com/maps/api/distancematrix/json',
+  validator: v.compose([
+    v.mutuallyExclusiveProperties(['arrival_time', 'departure_time']),
+    v.object({
+      arrival_time: v.optional(utils.timeStamp),
+      avoid: v.optional(utils.pipedArrayOf(v.oneOf([
+        'tolls', 'highways', 'ferries', 'indoor'
+      ]))),
+      departure_time: v.optional(utils.timeStamp),
+      destinations: utils.pipedArrayOf(utils.latLng),
+      mode: v.optional(v.oneOf(['driving', 'walking', 'bicycling', 'transit'])),
+      retryOptions: v.optional(utils.retryOptions),
+      transit_mode: v.optional(utils.pipedArrayOf(v.oneOf[
+        'bus', 'subway', 'train', 'tram', 'rail'
+      ])),
+      origins: utils.pipedArrayOf(utils.latLng)
+    })
+  ])
 };

--- a/lib/apis/elevation.js
+++ b/lib/apis/elevation.js
@@ -1,33 +1,23 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validateElevationQuery = v.object({
-  locations: utils.pipedArrayOf(utils.latLng)
-});
+exports.elevation = {
+  url: 'https://maps.googleapis.com/maps/api/elevation/json',
+  validator: v.object({
+    locations: utils.pipedArrayOf(utils.latLng)
+  })
+};
 
-var validateElevationAlongPathQuery = v.object({
-  path: function(path) {
-    if (typeof path == 'string') {
-      return 'enc:' + path;
-    } else {
-      return utils.pipedArrayOf(utils.latLng)(path);
-    }
-  },
-  samples: v.number
-});
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    elevation: function(query, callback) {
-      query = validateElevationQuery(query);
-      return makeApiCall(url, query, callback);
+exports.elevationAlongPath = {
+  url: 'https://maps.googleapis.com/maps/api/elevation/json',
+  validator: v.object({
+    path: function(path) {
+      if (typeof path == 'string') {
+        return 'enc:' + path;
+      } else {
+        return utils.pipedArrayOf(utils.latLng)(path);
+      }
     },
-
-    elevationAlongPath: function(query, callback) {
-      query = validateElevationAlongPathQuery(query);
-      return makeApiCall(url, query, callback);
-    }
-
-  };
+    samples: v.number
+  })
 };

--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -1,41 +1,31 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validateGeocodeQuery = v.compose([
-  v.mutuallyExclusiveProperties(['address', 'components']),
-  v.object({
-    address: v.optional(v.string),
-    bounds: v.optional(utils.bounds),
-    components: v.optional(utils.pipedKeyValues),
-    retryOptions: v.optional(utils.retryOptions)
-  })
-]);
+exports.geocode = {
+  url: 'https://maps.googleapis.com/maps/api/geocode/json',
+  validator: v.compose([
+    v.mutuallyExclusiveProperties(['address', 'components']),
+    v.object({
+      address: v.optional(v.string),
+      bounds: v.optional(utils.bounds),
+      components: v.optional(utils.pipedKeyValues),
+      retryOptions: v.optional(utils.retryOptions)
+    })
+  ])
+};
 
-var validateReverseGeocodeQuery = v.compose([
-  v.mutuallyExclusiveProperties(['latlng', 'place_id']),
-  v.object({
-    latlng: v.optional(utils.latLng),
-    location_type: v.optional(utils.pipedArrayOf(v.oneOf([
-      'ROOFTOP', 'RANGE_INTERPOLATED', 'GEOMETRIC_CENTER', 'APPROXIMATE'
-    ]))),
-    place_id: v.optional(v.string),
-    result_type: v.optional(utils.pipedArrayOf(v.string)),
-    retryOptions: v.optional(utils.retryOptions)
-  })
-]);
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    geocode: function(query, callback) {
-      query = validateGeocodeQuery(query);
-      return makeApiCall(url, query, callback);
-    },
-
-    reverseGeocode: function(query, callback) {
-      query = validateReverseGeocodeQuery(query);
-      return makeApiCall(url, query, callback);
-    }
-
-  };
+exports.reverseGeocode = {
+  url: 'https://maps.googleapis.com/maps/api/geocode/json',
+  validator: v.compose([
+    v.mutuallyExclusiveProperties(['latlng', 'place_id']),
+    v.object({
+      latlng: v.optional(utils.latLng),
+      location_type: v.optional(utils.pipedArrayOf(v.oneOf([
+        'ROOFTOP', 'RANGE_INTERPOLATED', 'GEOMETRIC_CENTER', 'APPROXIMATE'
+      ]))),
+      place_id: v.optional(v.string),
+      result_type: v.optional(utils.pipedArrayOf(v.string)),
+      retryOptions: v.optional(utils.retryOptions)
+    })
+  ])
 };

--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -1,59 +1,45 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validatePlacesQuery = v.object({
-  query: v.string,
-  language: v.optional(v.string),
-  location: v.optional(utils.latLng),
-  radius: v.optional(v.number),
-  minprice: v.optional(v.number),
-  maxprice: v.optional(v.number),
-  opennow: v.optional(v.boolean),
-  types: v.optional(v.array(v.string)),
-  pagetoken: v.optional(v.string)
-});
+exports.places = {
+  url: 'https://maps.googleapis.com/maps/api/place/textsearch/json',
+  validator: v.object({
+    query: v.string,
+    language: v.optional(v.string),
+    location: v.optional(utils.latLng),
+    radius: v.optional(v.number),
+    minprice: v.optional(v.number),
+    maxprice: v.optional(v.number),
+    opennow: v.optional(v.boolean),
+    types: v.optional(v.array(v.string)),
+    pagetoken: v.optional(v.string)
+  })
+};
 
-var validatePlaceQuery = v.object({
-  placeid: v.string,
-  language: v.optional(v.string)
-});
+exports.place = {
+  url: 'https://maps.googleapis.com/maps/api/place/details/json',
+  validator: v.object({
+    placeid: v.string,
+    language: v.optional(v.string)
+  })
+};
 
-var validatePlacesPhotoQuery = v.object({
-  photoreference: v.string,
-  maxwidth: v.optional(v.number),
-  maxheight: v.optional(v.number)
-});
+exports.placesPhoto = {
+  url: 'https://maps.googleapis.com/maps/api/place/photo',
+  validator: v.object({
+    photoreference: v.string,
+    maxwidth: v.optional(v.number),
+    maxheight: v.optional(v.number)
+  })
+};
 
-var validatePlacesAutoCompleteQuery = v.object({
-  input: v.string,
-  offset: v.optional(v.number),
-  location: v.optional(utils.latLng),
-  language: v.optional(v.string),
-  radius: v.optional(v.number)
-});
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    places: function(query, callback) {
-      query = validatePlacesQuery(query);
-      return makeApiCall(url + 'textsearch/json', query, callback);
-    },
-
-    place: function(query, callback) {
-      query = validatePlaceQuery(query);
-      return makeApiCall(url + 'details/json', query, callback);
-    },
-
-    placesPhoto: function(query, callback) {
-      query = validatePlacesPhotoQuery(query);
-      return makeApiCall(url + 'photo', query, callback);
-    },
-
-    placesAutoComplete: function(query, callback) {
-      query = validatePlacesAutoCompleteQuery(query);
-      return makeApiCall(url + 'queryautocomplete/json', query, callback);
-    }
-
-  };
+exports.placesAutoComplete = {
+  url: 'https://maps.googleapis.com/maps/api/place/queryautocomplete/json',
+  validator: v.object({
+    input: v.string,
+    offset: v.optional(v.number),
+    location: v.optional(utils.latLng),
+    language: v.optional(v.string),
+    radius: v.optional(v.number)
+  })
 };

--- a/lib/apis/roads.js
+++ b/lib/apis/roads.js
@@ -1,40 +1,28 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validateSnapToRoadsQuery = v.object({
-  path: utils.pipedArrayOf(utils.latLng),
-  interpolate: v.optional(v.boolean)
-});
+exports.snapToRoads = {
+  url: 'https://roads.googleapis.com/v1/snapToRoads',
+  supportsClientId: false,
+  validator: v.object({
+    path: utils.pipedArrayOf(utils.latLng),
+    interpolate: v.optional(v.boolean)
+  })
+};
 
-var validateSpeedLimitsQuery = v.object({
-  placeId: v.array(v.string),
-  interpolate: v.optional(v.boolean)
-});
+exports.speedLimits = {
+  url: 'https://roads.googleapis.com/v1/speedLimits',
+  supportsClientId: false,
+  validator: v.object({
+    placeId: v.array(v.string),
+    interpolate: v.optional(v.boolean)
+  })
+};
 
-var validateSnappedSpeedLimitsQuery = v.object({
-  path: utils.pipedArrayOf(utils.latLng)
-});
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    snapToRoads: function(query, callback) {
-      query = validateSnapToRoadsQuery(query);
-      query.supportsClientId = false;
-      return makeApiCall(url + 'snapToRoads', query, callback);
-    },
-
-    speedLimits: function(query, callback) {
-      query = validateSpeedLimitsQuery(query);
-      query.supportsClientId = false;
-      return makeApiCall(url + 'speedLimits', query, callback);
-    },
-
-    snappedSpeedLimits: function(query, callback) {
-      query = validateSnappedSpeedLimitsQuery(query);
-      query.supportsClientId = false;
-      return makeApiCall(url + 'speedLimits', query, callback);
-    }
-
-  };
+exports.snappedSpeedLimits = {
+  url: 'https://roads.googleapis.com/v1/speedLimits',
+  supportsClientId: false,
+  validator: v.object({
+    path: utils.pipedArrayOf(utils.latLng)
+  })
 };

--- a/lib/apis/timezone.js
+++ b/lib/apis/timezone.js
@@ -1,19 +1,11 @@
 var utils = require('../utils');
 var v = require('../validate');
 
-var validateTimezoneQuery = v.object({
-  location: utils.latLng,
-  retryOptions: v.optional(utils.retryOptions),
-  timestamp: utils.timeStamp
-});
-
-exports.inject = function(url, makeApiCall) {
-  return {
-
-    timezone: function(query, callback) {
-      query = validateTimezoneQuery(query);
-      return makeApiCall(url, query, callback);
-    }
-
-  };
-};
+exports.timezone = {
+	url: 'https://maps.googleapis.com/maps/api/timezone/json',
+	validator: v.object({
+	  location: utils.latLng,
+	  retryOptions: v.optional(utils.retryOptions),
+	  timestamp: utils.timeStamp
+	})
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ exports.init = function(options) {
     var key = options.key || process.env.GOOGLE_MAPS_API_KEY;
     var clientId = options.clientId || process.env.GOOGLE_MAPS_API_CLIENT_ID;
     var clientSecret = options.clientSecret || process.env.GOOGLE_MAPS_API_CLIENT_SECRET;
-    var useClientId = query.supportsClientId !== false && clientId && clientSecret;
+    var useClientId = query.supportsClientId && clientId && clientSecret;
     var retryOptions = query.retryOptions || options.retryOptions || {};
 
     delete query.retryOptions;
@@ -164,30 +164,37 @@ exports.init = function(options) {
     return handle;
   };
 
-  var baseUrl = 'https://maps.googleapis.com/maps/api/';
-  var geocode = require('./apis/geocode').inject(baseUrl + 'geocode/json', makeApiCall);
-  var timezone = require('./apis/timezone').inject(baseUrl + 'timezone/json', makeApiCall);
-  var directions = require('./apis/directions').inject(baseUrl + 'directions/json', makeApiCall);
-  var distanceMatrix = require('./apis/distance-matrix').inject(baseUrl + 'distancematrix/json', makeApiCall);
-  var elevation = require('./apis/elevation').inject(baseUrl + 'elevation/json', makeApiCall);
-  var roads = require('./apis/roads').inject('https://roads.googleapis.com/v1/', makeApiCall);
-  var places = require('./apis/places').inject(baseUrl + 'place/', makeApiCall);
+  var makeApiMethod = function(apiConfig) {
+    return function(query, callback) {
+      query = apiConfig.validator(query);
+      query.supportsClientId = apiConfig.supportsClientId !== false;
+      return makeApiCall(apiConfig.url, query, callback);
+    };
+  };
+
+  var geocode = require('./apis/geocode');
+  var timezone = require('./apis/timezone');
+  var directions = require('./apis/directions');
+  var distanceMatrix = require('./apis/distance-matrix');
+  var elevation = require('./apis/elevation');
+  var roads = require('./apis/roads');
+  var places = require('./apis/places');
 
   return {
-    geocode: geocode.geocode,
-    reverseGeocode: geocode.reverseGeocode,
-    timezone: timezone.timezone,
-    directions: directions.directions,
-    distanceMatrix: distanceMatrix.distanceMatrix,
-    elevation: elevation.elevation,
-    elevationAlongPath: elevation.elevationAlongPath,
-    snapToRoads: roads.snapToRoads,
-    speedLimits: roads.speedLimits,
-    snappedSpeedLimits: roads.snappedSpeedLimits,
-    places: places.places,
-    place: places.place,
-    placesPhoto: places.placesPhoto,
-    placesAutoComplete: places.placesAutoComplete
+    directions: makeApiMethod(directions.directions),
+    distanceMatrix: makeApiMethod(distanceMatrix.distanceMatrix),
+    elevation: makeApiMethod(elevation.elevation),
+    elevationAlongPath: makeApiMethod(elevation.elevationAlongPath),
+    geocode: makeApiMethod(geocode.geocode),
+    reverseGeocode: makeApiMethod(geocode.reverseGeocode),
+    places: makeApiMethod(places.places),
+    place: makeApiMethod(places.place),
+    placesPhoto: makeApiMethod(places.placesPhoto),
+    placesAutoComplete: makeApiMethod(places.placesAutoComplete),
+    snapToRoads: makeApiMethod(roads.snapToRoads),
+    speedLimits: makeApiMethod(roads.speedLimits),
+    snappedSpeedLimits: makeApiMethod(roads.snappedSpeedLimits),
+    timezone: makeApiMethod(timezone.timezone)
   };
 
 };


### PR DESCRIPTION
This is what we dreamt of a while ago - now all the APIs are defined as config instead of 3-line boilerplate methods. 

I think it makes sense to leave each API as a module under the `api` directory, as that'll serve as a good structure for containing all their respective jsdocs.
