### PR TITLE
Add a real timeout option.

### DIFF
--- a/lib/apis/directions.js
+++ b/lib/apis/directions.js
@@ -72,7 +72,8 @@ exports.directions = {
         'less_walking', 'fewer_transfers'
       ])),
       optimize: v.optional(v.boolean),
-      retryOptions: v.optional(utils.retryOptions)
+      retryOptions: v.optional(utils.retryOptions),
+      timeout: v.optional(v.number)
     }),
     function(query) {
       if (query.waypoints && query.optimize) {

--- a/lib/apis/distance-matrix.js
+++ b/lib/apis/distance-matrix.js
@@ -65,7 +65,8 @@ exports.distanceMatrix = {
       traffic_model: v.optional(v.oneOf([
         'best_guess', 'pessimistic', 'optimistic'
       ])),
-      retryOptions: v.optional(utils.retryOptions)
+      retryOptions: v.optional(utils.retryOptions),
+      timeout: v.optional(v.number)
     })
   ])
 };

--- a/lib/apis/elevation.js
+++ b/lib/apis/elevation.js
@@ -32,7 +32,8 @@ exports.elevation = {
   url: 'https://maps.googleapis.com/maps/api/elevation/json',
   validator: v.object({
     locations: utils.pipedArrayOf(utils.latLng),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -58,6 +59,7 @@ exports.elevationAlongPath = {
       }
     },
     samples: v.number,
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };

--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -42,7 +42,8 @@ exports.geocode = {
     bounds: v.optional(utils.bounds),
     region: v.optional(v.string),
     language: v.optional(v.string),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -74,7 +75,8 @@ exports.reverseGeocode = {
         'ROOFTOP', 'RANGE_INTERPOLATED', 'GEOMETRIC_CENTER', 'APPROXIMATE'
       ]))),
       language: v.optional(v.string),
-      retryOptions: v.optional(utils.retryOptions)
+      retryOptions: v.optional(utils.retryOptions),
+      timeout: v.optional(v.number)
     })
   ])
 };

--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -48,7 +48,8 @@ exports.places = {
     opennow: v.optional(v.boolean),
     types: v.optional(utils.pipedArrayOf(v.string)),
     pagetoken: v.optional(v.string),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -68,7 +69,8 @@ exports.place = {
   validator: v.object({
     placeid: v.string,
     language: v.optional(v.string),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -90,7 +92,8 @@ exports.placesPhoto = {
     photoreference: v.string,
     maxwidth: v.optional(v.number),
     maxheight: v.optional(v.number),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -120,6 +123,7 @@ exports.placesAutoComplete = {
     radius: v.optional(v.number),
     types: v.optional(utils.pipedArrayOf(v.string)),
     components: v.optional(utils.pipedKeyValues),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };

--- a/lib/apis/roads.js
+++ b/lib/apis/roads.js
@@ -35,7 +35,8 @@ exports.snapToRoads = {
   validator: v.object({
     path: utils.pipedArrayOf(utils.latLng),
     interpolate: v.optional(v.boolean),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -56,7 +57,8 @@ exports.speedLimits = {
   validator: v.object({
     placeId: v.array(v.string),
     units: v.optional(v.oneOf(['KPH', 'MPH'])),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };
 
@@ -77,6 +79,7 @@ exports.snappedSpeedLimits = {
   validator: v.object({
     path: utils.pipedArrayOf(utils.latLng),
     units: v.optional(v.oneOf(['KPH', 'MPH'])),
-    retryOptions: v.optional(utils.retryOptions)
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
   })
 };

--- a/lib/apis/timezone.js
+++ b/lib/apis/timezone.js
@@ -31,11 +31,12 @@ var v = require('../internal/validate');
  * @return {RequestHandle}
  */
 exports.timezone = {
-	url: 'https://maps.googleapis.com/maps/api/timezone/json',
-	validator: v.object({
-	  location: utils.latLng,
-	  timestamp: utils.timeStamp,
-	  language: v.optional(v.string),
-	  retryOptions: v.optional(utils.retryOptions)
-	})
-}
+  url: 'https://maps.googleapis.com/maps/api/timezone/json',
+  validator: v.object({
+    location: utils.latLng,
+    timestamp: utils.timeStamp,
+    language: v.optional(v.string),
+    retryOptions: v.optional(utils.retryOptions),
+    timeout: v.optional(v.number)
+  })
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,12 +29,12 @@
  * @param {string=} options.clientId Maps API for Work client ID.
  * @param {string=} options.clientSecret Maps API for Work client secret (a.k.a.
  *     private key).
+ * @param {number=} options.timeout Timeout in milliseconds.
+ *     (Default: 60 * 1000 ms)
  * @param {number=} options.rate.limit Controls rate-limiting of requests.
  *     Maximum number of requests per period. (Default: 10)
  * @param {number=} options.rate.period Period for rate limit, in milliseconds.
  *     (Default: 1000 ms)
- * @param {number=} options.retryOptions.timeout Timeout in milliseconds.
- *     (Default: 60 * 1000 ms)
  * @param {number=} options.retryOptions.interval If a transient server error
  *     occurs, how long to wait before retrying the request, in milliseconds.
  *     (Default: 500 ms)

--- a/lib/internal/attempt.js
+++ b/lib/internal/attempt.js
@@ -17,7 +17,7 @@
 
 var Task = require('./task');
 
-exports.inject = function(setTimeout, getTime) {
+exports.inject = function(setTimeout) {
   /**
    * Returns a task that waits for the given delay.
    * @param  {number} delayMs
@@ -45,12 +45,9 @@ exports.inject = function(setTimeout, getTime) {
     attempt: function(options) {
       var doSomething = options['do'];
       var isSuccessful = options.until;
-      var timeout = options.timeout || 60 * 1000;
       var interval = options.interval || 500;
       var increment = options.increment || 1.5;
       var jitter = options.jitter || 0.5;
-
-      var startTime = getTime();
 
       return Task.withValue(null)
       .thenDo(function loop(err) {
@@ -67,10 +64,6 @@ exports.inject = function(setTimeout, getTime) {
 
           var delay = interval * (1 + jitter * (2 * Math.random() - 1));
           interval *= increment;
-          if (getTime() + delay >= startTime + timeout) {
-            return Task.withValue(new Error('timeout'), null);
-          }
-
           return wait(delay).thenDo(loop);
         });
       });

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -31,7 +31,7 @@ exports.inject = function(options) {
   var makeUrlRequest = options.makeUrlRequest || require('./make-url-request');
   var mySetTimeout = options.setTimeout || setTimeout;
   var getTime = options.getTime || function() {return new Date().getTime();};
-  var attempt = require('./attempt').inject(mySetTimeout, getTime).attempt;
+  var attempt = require('./attempt').inject(mySetTimeout).attempt;
   var ThrottledQueue = require('./throttled-queue').inject(mySetTimeout, getTime);
   var requestQueue = ThrottledQueue.create(rateLimit, ratePeriod);
 
@@ -61,10 +61,13 @@ exports.inject = function(options) {
   return function(path, query, callback) {
 
     var useClientId = query.supportsClientId && clientId && clientSecret;
-    var retryOptions = query.retryOptions || options.retryOptions || {};
-
-    delete query.retryOptions;
     delete query.supportsClientId;
+
+    var retryOptions = query.retryOptions || options.retryOptions || {};
+    delete query.retryOptions;
+
+    var timeout = query.timeout || options.timeout || 60 * 1000;
+    delete query.timeout;
 
     if (useClientId) {
       query.client = clientId;
@@ -100,18 +103,26 @@ exports.inject = function(options) {
       });
     }
 
-    var task = attempt({
-      'do': rateLimitedGet,
-      until: function(response) {
-        return !!response
-            && response.status !== 500
-            && response.status !== 503
-            && response.status !== 504;
-      },
-      interval: retryOptions.interval,
-      increment: retryOptions.increment,
-      jitter: retryOptions.jitter,
-      timeout: retryOptions.timeout
+    var task = Task.start(function(raceCallback) {
+      var requestTask = attempt({
+        'do': rateLimitedGet,
+        until: function(response) {
+          return !!response
+              && response.status !== 500
+              && response.status !== 503
+              && response.status !== 504;
+        },
+        interval: retryOptions.interval,
+        increment: retryOptions.increment,
+        jitter: retryOptions.jitter
+      });
+
+      // Race the request and the timeout.
+      requestTask.thenDo(raceCallback);
+      mySetTimeout(function() {
+        raceCallback('timeout', null);
+        requestTask.cancel();
+      }, timeout);
     })
     .thenDo(function(err, response) {
       if (callback) {


### PR DESCRIPTION
Previously, the retryOptions.timeout was lame, and only affected when we would stop retrying a request.
Now, the new timeout actually cancels the request when the time has lapsed.
