### PR TITLE
Fix "socket hang up" error

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -43,7 +43,7 @@ module.exports = function makeUrlRequest(url, onSuccess, onError) {
   options.headers = {
     'User-Agent': 'GoogleGeoApiClientJS/' + version
   };
-  
+
   var request = https.get(options, function(response) {
 
     response.on('error', function(error) {
@@ -73,6 +73,8 @@ module.exports = function makeUrlRequest(url, onSuccess, onError) {
       onSuccess(response);
     }
 
+  }).on('error', function(error) {
+    onError(error)
   });
 
   return function cancel() { request.abort(); };


### PR DESCRIPTION
I had been getting a fatal "socket hang up" error occasionally while using this module which was killing my app. Some [research](http://stackoverflow.com/a/21957469/3187556) showed that you need to listen for errors on the `ClientRequest` object and not just the `ServerResponse`. This pull request implements that fix. I have signed the CLA.