### PR TITLE
Fix timestamp conversion to accept Unix time

### DIFF
--- a/lib/internal/convert.js
+++ b/lib/internal/convert.js
@@ -71,9 +71,12 @@ exports.timeStamp = function(arg) {
   }
   if (arg.getTime) {
     arg = arg.getTime();
+    // NOTE: Unix time is seconds past epoch.
+    return Math.round(arg / 1000);
   }
-  // NOTE: Unix time is seconds past epoch.
-  return Math.round(arg / 1000);
+
+  // Otherwise assume arg is Unix time
+  return arg;
 };
 
 exports.retryOptions = v.object({


### PR DESCRIPTION
Resolves issue #38. Currently if a Unix timestamp (seconds since epoch) is passed to the `timeStamp` conversion method it will be divided by 1000. This should only happen to values from Javascript's `Date.getTime()`, which returns milliseconds since epoch.