### PR TITLE
Properly cancel timers

### DIFF
--- a/lib/internal/attempt.js
+++ b/lib/internal/attempt.js
@@ -15,19 +15,8 @@
  * limitations under the License.
  */
 
-var Task = require('./task');
-
-exports.inject = function(setTimeout) {
-  /**
-   * Returns a task that waits for the given delay.
-   * @param  {number} delayMs
-   * @return {Task<undefined>}
-   */
-  function wait(delayMs) {
-    return Task.start(function(resolve) {
-      setTimeout(resolve, delayMs);
-    });
-  }
+exports.inject = function(wait) {
+  var Task = require('./task');
 
   return {
     /**

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -86,7 +86,9 @@ exports.inject = function(options) {
       });
     }
 
-    var timeoutTask = wait(timeout);
+    var timeoutTask = wait(timeout).thenDo(function() {
+      throw 'timeout';
+    });
     var requestTask = attempt({
       'do': rateLimitedGet,
       until: function(response) {
@@ -102,21 +104,11 @@ exports.inject = function(options) {
       jitter: retryOptions.jitter
     });
 
-    // Race the request and the timeout.
-    var task = Task.start(function(resolve, reject) {
-      timeoutTask.thenDo(function() {
-        reject('timeout');
-      }).finally(function() {
-        requestTask.cancel();
-      });
-
-      requestTask.thenDo(resolve, reject).finally(function() {
-        timeoutTask.cancel();
-      });
-    })
-    .thenDo(
-        function(response) { callback(null, response); },
-        function(err) { callback(err); });
+    var task =
+        Task.race([timeoutTask, requestTask])
+        .thenDo(
+            function(response) { callback(null, response); },
+            function(err) { callback(err); });
 
     if (options.Promise) {
       var originalCallback = callback;

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -32,9 +32,11 @@ exports.inject = function(options) {
 
   var makeUrlRequest = options.makeUrlRequest || require('./make-url-request');
   var mySetTimeout = options.setTimeout || setTimeout;
+  var myClearTimeout = options.clearTimeout || clearTimeout;
   var getTime = options.getTime || function() {return new Date().getTime();};
-  var attempt = require('./attempt').inject(mySetTimeout).attempt;
-  var ThrottledQueue = require('./throttled-queue').inject(mySetTimeout, getTime);
+  var wait = require('./wait').inject(mySetTimeout, myClearTimeout);
+  var attempt = require('./attempt').inject(wait).attempt;
+  var ThrottledQueue = require('./throttled-queue').inject(wait, getTime);
   var requestQueue = ThrottledQueue.create(rateLimit, ratePeriod);
 
   /**
@@ -84,28 +86,33 @@ exports.inject = function(options) {
       });
     }
 
+    var timeoutTask = wait(timeout);
+    var requestTask = attempt({
+      'do': rateLimitedGet,
+      until: function(response) {
+        return !(
+            response == null
+            || response.status === 500
+            || response.status === 503
+            || response.status === 504
+            || response.json && response.json.status === 'OVER_QUERY_LIMIT');
+      },
+      interval: retryOptions.interval,
+      increment: retryOptions.increment,
+      jitter: retryOptions.jitter
+    });
+
+    // Race the request and the timeout.
     var task = Task.start(function(resolve, reject) {
-      var requestTask = attempt({
-        'do': rateLimitedGet,
-        until: function(response) {
-          return !(
-              response == null
-              || response.status === 500
-              || response.status === 503
-              || response.status === 504
-              || response.json && response.json.status === 'OVER_QUERY_LIMIT');
-        },
-        interval: retryOptions.interval,
-        increment: retryOptions.increment,
-        jitter: retryOptions.jitter
+      timeoutTask.thenDo(function() {
+        reject('timeout');
+      }).finally(function() {
+        requestTask.cancel();
       });
 
-      // Race the request and the timeout.
-      requestTask.thenDo(resolve, reject);
-      mySetTimeout(function() {
-        reject('timeout');
-        requestTask.cancel();
-      }, timeout);
+      requestTask.thenDo(resolve, reject).finally(function() {
+        timeoutTask.cancel();
+      });
     })
     .thenDo(
         function(response) { callback(null, response); },

--- a/lib/internal/task.js
+++ b/lib/internal/task.js
@@ -55,11 +55,16 @@ Task.start = function(doSomething) {
   // finished or onFinish.
   var finished;
   var onFinish;
+  var cleaners = [];
 
   function finish(err, result) {
     if (!finished) {
       finished = {err: err, result: result};
       if (onFinish) onFinish();
+      var cleanup;
+      while (cleanup = cleaners.pop()) {
+        cleanup();
+      }
     }
   }
 
@@ -131,9 +136,13 @@ Task.start = function(doSomething) {
    * @return {THIS}
    */
   me.finally = function(cleanup) {
-    setListener(function() {
+    if (!finished) {
+      cleaners.push(function() {
+        process.nextTick(cleanup);
+      });
+    } else {
       process.nextTick(cleanup);
-    });
+    }
     return me;
   };
 
@@ -146,6 +155,29 @@ Task.start = function(doSomething) {
 Task.withValue = function(result) {
   return Task.start(function(resolve) {
     resolve(result);
+  });
+};
+
+/**
+ * Returns a new task that races the given tasks. Eventually finishes with the
+ * result or error of whichever task finishes first. If any task is cancelled,
+ * all of the tasks are cancelled.
+ *
+ * @param {Array<Task<T>>} tasks
+ * @return {Task<T>}
+ * @template T
+ */
+Task.race = function(tasks) {
+  return Task.start(function(resolve, reject) {
+    function cancelAll() {
+      tasks.forEach(function(task) {
+        task.cancel();
+      });
+    }
+    tasks.forEach(function(task) {
+      task.finally(cancelAll).thenDo(resolve, reject);
+    });
+    return cancelAll;
   });
 };
 

--- a/lib/internal/task.js
+++ b/lib/internal/task.js
@@ -21,11 +21,9 @@
 // (b) Promises aren't cancellable (yet?), and I want cancellability.
 //
 // This is very stripped down, compared to Promises.
-// (a) You can only call .thenDo() once.
-// (b) Tasks always complete with a pair (err, result).
-// (c) Regardless of errors or cancellation, the argument of .thenDo() is
-//     *always* executed, and asynchronously.
-// (d) The argument to .thenDo() must return either undefined or a Task. I don't
+// (a) You can only call .thenDo() once. Because there's only one party waiting
+//     on the result of a task, cancelling always propagates backwards.
+// (b) The argument to .thenDo() must return either undefined or a Task. I don't
 //     promote values to Tasks, like what happens with Promises.
 
 var Task = exports;
@@ -81,8 +79,8 @@ Task.start = function(doSomething) {
    * Cancels the task (unless the task has already finished, in which case
    * this call is ignored).
    *
-   * If there is a subsequent task scheduled (using #thenDo) it will be called
-   * with the pair ('cancelled', null).
+   * Subsequent tasks created with #thenDo will not be started. However, clean-
+   * up code added with #finished will run.
    */
   me.cancel = function() {
     if (!finished) {

--- a/lib/internal/throttled-queue.js
+++ b/lib/internal/throttled-queue.js
@@ -18,7 +18,7 @@
 var CircularBuffer = require('./circular-buffer');
 var Task = require('./task');
 
-exports.inject = function(setTimeout, getTime) {
+exports.inject = function(wait, getTime) {
   return {
     /**
      * Creates a ThrottledQueue. The queue stores tasks, which will be executed
@@ -44,7 +44,7 @@ exports.inject = function(setTimeout, getTime) {
         delay = (lastTime != undefined && delay > 0) ? delay : 0;
 
         scheduled = true;
-        setTimeout(function() {
+        wait(delay).thenDo(function() {
           scheduled = false;
 
           var action = queue.shift();
@@ -53,7 +53,7 @@ exports.inject = function(setTimeout, getTime) {
           if (queue.length) {
             schedule();
           }
-        }, delay);
+        });
       }
 
       /**

--- a/lib/internal/throttled-queue.js
+++ b/lib/internal/throttled-queue.js
@@ -32,29 +32,8 @@ exports.inject = function(wait, getTime) {
      */
     create: function(limit, period) {
       var me = {};
-      var queue = [];
+      var queue = Task.withValue();
       var recentTimes = CircularBuffer.create(limit);
-      var scheduled = false;
-
-      function schedule() {
-        if (scheduled) return;
-
-        var lastTime = recentTimes.item(limit - 1);
-        var delay = lastTime + period - getTime();
-        delay = (lastTime != undefined && delay > 0) ? delay : 0;
-
-        scheduled = true;
-        wait(delay).thenDo(function() {
-          scheduled = false;
-
-          var action = queue.shift();
-          if (action) action();
-
-          if (queue.length) {
-            schedule();
-          }
-        });
-      }
 
       /**
        * Adds a task to the work queue.
@@ -65,24 +44,28 @@ exports.inject = function(wait, getTime) {
        * @template T
        */
       me.add = function(doSomething) {
-        schedule();
-
-        return Task.start(function(resolve) {
-          var cancelled;
-
-          // Call the callback when the action is popped off the queue
-          // (unless we were cancelled in the meantime).
-          queue.push(function() {
-            if (!cancelled) {
+        // Return a separate task from the queue, so that cancelling a task
+        // doesn't propagate back and cancel the whole queue.
+        var waitForMyTurn = Task
+            .start(function(resolve) {
+              queue.finally(resolve);
+            })
+            .thenDo(function() {
+              var lastTime = recentTimes.item(limit - 1);
+              if (lastTime == undefined) return;
+              return wait(Math.max(lastTime + period - getTime(), 0));
+            })
+            .thenDo(function() {
               recentTimes.insert(getTime());
-              resolve();
-            }
+            });
+
+        queue = queue.thenDo(function() {
+          return Task.start(function(resolve) {
+            waitForMyTurn.finally(resolve);
           });
-          return function onCancel() {
-            cancelled = true;
-          };
-        })
-        .thenDo(doSomething);
+        });
+
+        return waitForMyTurn.thenDo(doSomething);
       };
 
       return me;

--- a/lib/internal/wait.js
+++ b/lib/internal/wait.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Task = require('./task');
+
+exports.inject = function(setTimeout, clearTimeout) {
+  /**
+   * Returns a task that waits for the given delay.
+   * @param  {number} delayMs
+   * @return {Task<undefined>}
+   */
+  return function wait(delayMs) {
+    return Task.start(function(resolve) {
+      var id = setTimeout(resolve, delayMs);
+      return function cancel() {
+        clearTimeout(id);
+      };
+    });
+  }
+};

--- a/spec/mock-clock.js
+++ b/spec/mock-clock.js
@@ -26,6 +26,7 @@ MockClock.create = function(opt_startTime) {
     return b.time - a.time;
   });
   var nextId = 100;
+  var cancelledCallbacks = {};
 
   var me = {};
 
@@ -43,6 +44,10 @@ MockClock.create = function(opt_startTime) {
     return id;
   };
 
+  me.clearTimeout = function(id) {
+    cancelledCallbacks[id] = true;
+  };
+
   me.run = function(opt_duration) {
     var endTime = opt_duration + theTime;
 
@@ -58,7 +63,9 @@ MockClock.create = function(opt_startTime) {
       var item = queue.deq();
 
       theTime = item.time;
-      item.callback();
+      if (!cancelledCallbacks[item.id]) {
+        item.callback();
+      }
 
       // Wait a bit to allow process.nextTick() and setImmediate to happen.
       return wait1ms().thenDo(loop);

--- a/spec/unit/attempt-spec.js
+++ b/spec/unit/attempt-spec.js
@@ -24,9 +24,9 @@ describe('attempt', function() {
   var attempt;
   beforeEach(function() {
     clock = MockClock.create();
-    attempt = require('../../lib/internal/attempt')
-        .inject(clock.setTimeout)
-        .attempt;
+    var wait = require('../../lib/internal/wait')
+        .inject(clock.setTimeout, clock.clearTimeout);
+    attempt = require('../../lib/internal/attempt').inject(wait).attempt;
   });
 
   var equalTo200;

--- a/spec/unit/index-spec.js
+++ b/spec/unit/index-spec.js
@@ -92,7 +92,8 @@ describe('index.js:', function() {
       createClient({
         makeUrlRequest: requestAndFail,
         getTime: clock.getTime,
-        setTimeout: clock.setTimeout
+        setTimeout: clock.setTimeout,
+        clearTimeout: clock.clearTimeout
       })
       .geocode({
         address: 'Sydney Opera House',
@@ -116,6 +117,7 @@ describe('index.js:', function() {
         makeUrlRequest: requestAndFail,
         getTime: clock.getTime,
         setTimeout: clock.setTimeout,
+        clearTimeout: clock.clearTimeout,
         timeout: 100,
         retryOptions: {
           interval: 30,
@@ -139,6 +141,7 @@ describe('index.js:', function() {
         makeUrlRequest: requestAndSucceed,
         getTime: clock.getTime,
         setTimeout: clock.setTimeout,
+        clearTimeout: clock.clearTimeout,
         rate: {limit: 3, period: 30}
       });
 
@@ -158,6 +161,7 @@ describe('index.js:', function() {
         makeUrlRequest: requestAndSucceed,
         getTime: clock.getTime,
         setTimeout: clock.setTimeout,
+        clearTimeout: clock.clearTimeout,
         rate: {period: 20}
       });
 

--- a/spec/unit/task-spec.js
+++ b/spec/unit/task-spec.js
@@ -183,3 +183,41 @@ describe('Task:', function() {
     });
   });
 });
+
+describe('Task.race', function() {
+  var task1, resolve1, cancelled1;
+  var task2, resolve2, cancelled2;
+  beforeEach(function() {
+    task1 = Task.start(function(resolve) {
+      resolve1 = resolve;
+      cancelled1 = jasmine.createSpy('cancelled1');
+      return cancelled1;
+    });
+    task2 = Task.start(function(resolve) {
+      resolve2 = resolve;
+      cancelled2 = jasmine.createSpy('cancelled2');
+      return cancelled2;
+    });
+  });
+
+  it('cancels the second task if the first task finishes', function(done) {
+    Task.race([task1, task2]).thenDo(function(result) {
+      expect(result).toBe(42);
+      expect(cancelled2).toHaveBeenCalled();
+      done();
+    });
+
+    resolve1(42);
+  });
+
+  it('cancels both tasks if the race is cancelled', function(done) {
+    Task.race([task1, task2])
+    .thenDo(fail)
+    .finally(function() {
+      expect(cancelled1).toHaveBeenCalled();
+      expect(cancelled2).toHaveBeenCalled();
+      done();
+    })
+    .cancel();
+  });
+});


### PR DESCRIPTION
Timers are used in several places:
* request timeout
* throttled queue
* retry with exponential back-off

This change makes cancelling properly stop the timers.