### PR TITLE
Fix placesNearby rankby parameter

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -67,7 +67,7 @@ exports.places = {
  * @param {number} [query.maxprice]
  * @param {string} [query.name]
  * @param {boolean} [query.opennow]
- * @param {string} [query.rankBy] Either 'prominence' or 'distance'
+ * @param {string} [query.rankby] Either 'prominence' or 'distance'
  * @param {string} [query.type]
  * @param {string} [query.pagetoken]
  * @param {ResponseCallback} callback Callback function for handling the result
@@ -84,7 +84,7 @@ exports.placesNearby = {
     maxprice: v.optional(v.number),
     name: v.optional(v.string),
     opennow: v.optional(v.boolean),
-    rankBy: v.optional(v.oneOf(['prominence', 'distance'])),
+    rankby: v.optional(v.oneOf(['prominence', 'distance'])),
     type: v.optional(v.string),
     pagetoken: v.optional(v.string),
     retryOptions: v.optional(utils.retryOptions),

--- a/spec/e2e/places-spec.js
+++ b/spec/e2e/places-spec.js
@@ -69,6 +69,28 @@ describe('places client library', function() {
     .then(done, fail);
   });
 
+  it('gets places for a nearby search query ranked by distance', function(done) {
+    googleMaps.placesNearby({
+      language: 'en',
+      location: [-33.865, 151.038],
+      rankby: 'distance',
+      minprice: 1,
+      maxprice: 4,
+      opennow: true,
+      type: 'restaurant'
+    })
+    .asPromise()
+    .then(function(response) {
+      expect(response.json.results).toEqual(
+          arrayContaining([
+            objectContaining({
+              name: stringMatching('McDonalds')
+            })
+          ]));
+    })
+    .then(done, fail);
+  });
+
   it('gets places for a radar search query', function(done) {
     googleMaps.placesRadar({
       language: 'en',


### PR DESCRIPTION
Changed ‘rankBy’ parameter to ‘rankby’. Using ‘rankBy’ always returns zero results.

Added test case for nearby places search ranked by distance.

Documentation at https://developers.google.com/maps/documentation/javascript/places should also be updated. Already submitted feedback.