### PR TITLE
Updated query.type doc for autocomplete in places.js

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -182,7 +182,7 @@ exports.placesPhoto = {
  * @param {LatLng} [query.location]
  * @param {string} [query.language]
  * @param {number} [query.radius]
- * @param {Array<string>} [query.types]
+ * @param {string} [query.type]
  * @param {Array<string>} [query.components]
  * @param {ResponseCallback} callback Callback function for handling the result
  * @return {RequestHandle}


### PR DESCRIPTION
I filed issue https://github.com/googlemaps/google-maps-services-js/issues/46 but decided to just make a PR.

Looks like the code was updated  in https://github.com/googlemaps/google-maps-services-js/commit/1d55956ecfc8132de2a9528127323b8d15088ca6 but documentation wasn't.

