### PR TITLE
Treat unsuccessful API responses as errors

### DIFF
--- a/docs/interfaces.js
+++ b/docs/interfaces.js
@@ -8,21 +8,21 @@
  * The object given to the {@link ResponseCallback}, containing the HTTP status
  * and headers, as well as the response JSON.
  *
- * @interface Response
+ * @interface ClientResponse
  */
 /**
  * The HTTP status.
- * @name  Response#status
+ * @name  ClientResponse#status
  * @type {number}
  */
 /**
  * The HTTP headers.
- * @name  Response#headers
+ * @name  ClientResponse#headers
  * @type {Object}
  */
 /**
  * Deserialized JSON object for the API response.
- * @name  Response#json
+ * @name  ClientResponse#json
  * @type {Object}
  */
 
@@ -31,12 +31,12 @@
  * completes. The callback is given either:
  *
  * <ul>
- *   <li> a successful {@link Response} object; or
+ *   <li> a successful {@link ClientResponse} object; or
  *   <li> an error, one of:
  *     <ul>
  *       <li> the string <code>"timeout"</code>; or
  *       <li> an error from the underlying <code>http</code> library; or
- *       <li> a {@link Response} whose status is not <code>OK</code>.
+ *       <li> a {@link ClientResponse} whose status is not <code>OK</code>.
  *     </ul>
  * </ul>
  *
@@ -106,7 +106,7 @@
  *
  * @name  RequestHandle#asPromise
  * @function
- * @return {Promise<Response>}
+ * @return {Promise<ClientResponse>}
  */
 
 /**

--- a/docs/interfaces.js
+++ b/docs/interfaces.js
@@ -31,18 +31,27 @@
  * completes. The callback is given either:
  *
  * <ul>
- *   <li> a {@link Response} object; OR
- *   <li> an error object from the underlying <code>http</code> library.
+ *   <li> a successful {@link Response} object; or
+ *   <li> an error, one of:
+ *     <ul>
+ *       <li> the string <code>"timeout"</code>; or
+ *       <li> an error from the underlying <code>http</code> library; or
+ *       <li> a {@link Response} whose status is not <code>OK</code>.
+ *     </ul>
  * </ul>
  *
  * For example:
  *
  * <pre>
  *   googleMapsClient.geocode({...}, function(err, response) {
- *     if (err) {
- *       // Handle error.
- *     } else {
+ *     if (!err) {
  *       // Handle response.
+ *     } else if (err === 'timeout') {
+ *       // Handle timeout.
+ *     } else if (err.json) {
+ *       // Inspect err.status for more info.
+ *     } else {
+ *       // Handle network error.
  *     }
  *   });
  * </pre>

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -107,7 +107,9 @@ exports.inject = function(options) {
     var task =
         Task.race([timeoutTask, requestTask])
         .thenDo(function(response) {
-          if (response.status === 200 && response.json.status === 'OK') {
+          if (response.status === 200 && (
+                  response.json.status === 'OK' ||
+                  response.json.status === 'ZERO_RESULTS')) {
             return Task.withValue(response);
           } else {
             return Task.withError(response);

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -106,6 +106,13 @@ exports.inject = function(options) {
 
     var task =
         Task.race([timeoutTask, requestTask])
+        .thenDo(function(response) {
+          if (response.status === 200 && response.json.status === 'OK') {
+            return Task.withValue(response);
+          } else {
+            return Task.withError(response);
+          }
+        })
         .thenDo(
             function(response) { callback(null, response); },
             function(err) { callback(err); });

--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -34,7 +34,7 @@ var version = require('../version');
  * Returns a function that cancels the request.
  *
  * @param {string} url
- * @param {function(Response)} onSuccess
+ * @param {function(ClientResponse)} onSuccess
  * @param {function(?)} onError
  * @return {function()}
  */

--- a/lib/internal/task.js
+++ b/lib/internal/task.js
@@ -157,6 +157,15 @@ Task.withValue = function(result) {
 };
 
 /**
+ * Creates a Task with the given error.
+ */
+Task.withError = function(err) {
+  return Task.start(function(resolve, reject) {
+    reject(err);
+  });
+};
+
+/**
  * Returns a new task that races the given tasks. Eventually finishes with the
  * result or error of whichever task finishes first. If any task is cancelled,
  * all of the tasks are cancelled.

--- a/spec/unit/index-spec.js
+++ b/spec/unit/index-spec.js
@@ -261,6 +261,24 @@ describe('index.js:', function() {
       .then(done, fail);
     });
 
+    it('delivers ZERO_RESULTS as success', function(done) {
+      createClient({
+        Promise: Promise,
+        makeUrlRequest: function(url, onSuccess) {
+          onSuccess({status: 200, json: {status: 'ZERO_RESULTS'}});
+        }
+      })
+      .geocode({address: 'Sydney Opera House'})
+      .asPromise()
+      .then(function(response) {
+        expect(response).toEqual({
+          status: 200,
+          json: {status: 'ZERO_RESULTS'}
+        });
+      })
+      .then(done, fail);
+    });
+
     it('delivers errors', function(done) {
       createClient({
         Promise: Promise,
@@ -272,6 +290,21 @@ describe('index.js:', function() {
       .asPromise()
       .then(fail, function(error) {
         expect(error).toEqual('error');
+        done();
+      })
+    });
+
+    it('delivers REQUEST_DENIED as an error', function(done) {
+      createClient({
+        Promise: Promise,
+        makeUrlRequest: function(url, onSuccess) {
+          onSuccess({status: 200, json: {status: 'REQUEST_DENIED'}});
+        }
+      })
+      .geocode({address: 'Sydney Opera House'})
+      .asPromise()
+      .then(fail, function(error) {
+        expect(error.json).toEqual({status: 'REQUEST_DENIED'});
         done();
       })
     });

--- a/spec/unit/index-spec.js
+++ b/spec/unit/index-spec.js
@@ -32,7 +32,7 @@ describe('index.js:', function() {
           requestTimes.push(clock.getTime());
           onSuccess({
             status: 200,
-            json: {'hello': 'world'}
+            json: {status: 'OK'}
           });
         });
 
@@ -50,7 +50,7 @@ describe('index.js:', function() {
         expect(err).toBe(null);
         expect(response).toEqual({
           status: 200,
-          json: {'hello': 'world'}
+          json: {status: 'OK'}
         });
         done();
       });
@@ -255,7 +255,7 @@ describe('index.js:', function() {
       .then(function(response) {
         expect(response).toEqual({
           status: 200,
-          json: {'hello': 'world'}
+          json: {status: 'OK'}
         });
       })
       .then(done, fail);


### PR DESCRIPTION
Note: this is a breaking change to the library.

Fixes #32 