### PR TITLE
Prevent the licenses turning up in the generated jsdoc.

### DIFF
--- a/lib/apis/directions.js
+++ b/lib/apis/directions.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/distance-matrix.js
+++ b/lib/apis/distance-matrix.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/elevation.js
+++ b/lib/apis/elevation.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/roads.js
+++ b/lib/apis/roads.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');

--- a/lib/apis/timezone.js
+++ b/lib/apis/timezone.js
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */;
 
 var utils = require('../internal/convert');
 var v = require('../internal/validate');


### PR DESCRIPTION
See https://googlemaps.github.io/google-maps-services-js/docs/global.html#utils