### PR TITLE
speed up response by 4x fold

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -19,6 +19,11 @@ var https = require('https');
 var parse = require('url').parse;
 var version = require('../version');
 
+
+// add keep-alive header to speed up request
+https.globalAgent.keepAlive = true;
+
+
 /**
  * Makes a secure HTTP GET request for the given URL.
  *


### PR DESCRIPTION
Current response time is around 1000ms, because it creates a new socket and close it for every single request. This is too slow for some applications.

I added 1 single line, to use keep-alive, and this cuts the time down to ~250ms.