### PR TITLE
Fixed handling multibyte encoding responses

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -61,15 +61,15 @@ module.exports = function makeUrlRequest(url, onSuccess, onError) {
       makeUrlRequest(url, onSuccess, onError)
     } else if (response.headers['content-type'] == 'application/json; charset=UTF-8') {
       // Handle JSON.
-      var data = '';
+      var data = [];
       response.on('data', function(chunk) {
-        data += chunk;
+        data.push(chunk);
       });
       response.on('end', function() {
         onSuccess({
           status: response.statusCode,
           headers: response.headers,
-          json: JSON.parse(data)
+          json: JSON.parse(Buffer.concat(data).toString())
         })
       });
     } else {


### PR DESCRIPTION
Hi!

I see an issue with wrong HTTPS response chunks concatenation with multibyte strings in this code:
`
      var data = '';
      response.on('data', function(chunk) {
        data += chunk;
      });
`
Please consider to review my pull request, fixing this issue.
