### PR TITLE
Update docs on proper usage of `asPromise()`

### DIFF
--- a/docs/HOME.md
+++ b/docs/HOME.md
@@ -55,7 +55,17 @@ be used to cancel the request, or to obtain a Promise for the response.
 
 NOTE: Promises are only available if you supply a
 [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-constructor to the [`createClient()`](module-@google_maps.html#.createClient) method.
+constructor to the [`createClient()`](module-@google_maps.html#.createClient) method. You must also chain `.asPromise()` to a method before any `.then()` or `.catch()` methods.
+For example: 
+```js
+googleMapsClient.geocode({address: '1600 Amphitheatre Parkway, Mountain View, CA'}).asPromise()
+  .then((response) => {
+    console.log(response.json.results);
+  })
+  .catch((err) => {
+    console.log(err);
+  });
+ ```
 
 
 Learn More

--- a/docs/HOME.md
+++ b/docs/HOME.md
@@ -17,7 +17,7 @@ var googleMapsClient = require('@google/maps').createClient({
 Make requests to the Google Maps APIs by calling methods on the
 [client object](GoogleMapsClient.html):
 
-```
+```js
 // Geocode an address.
 googleMapsClient.geocode({
   address: '1600 Amphitheatre Parkway, Mountain View, CA'
@@ -58,6 +58,7 @@ NOTE: Promises are only available if you supply a
 constructor to the [`createClient()`](module-@google_maps.html#.createClient) method. You must also chain `.asPromise()` to a method before any `.then()` or `.catch()` methods.
 For example: 
 ```js
+// Geocode an address with a promise
 googleMapsClient.geocode({address: '1600 Amphitheatre Parkway, Mountain View, CA'}).asPromise()
   .then((response) => {
     console.log(response.json.results);


### PR DESCRIPTION
In reference to #89 

I left the syntax in the example for promises very simple. The `asPromise()` could arguably be on the next line, like the following:
```js
googleMapsClient.geocode({address: '1600 Amphitheatre Parkway, Mountain View, CA'})
  .asPromise()
  .then((response) => {
    console.log(response.json.results);
  })
  .catch((err) => {
    console.log(err);
  });
```
But, I wanted people to see that it is chained onto the `googleMapsClient` directly and thought the code in the actual PR was more clear.

I also noticed that the second code example in the docs does not have the `js` declaration within the markdown to highlight it is javascript. "```js" would syntax highlight the following
```js
// Geocode an address.
googleMapsClient.geocode({
  address: '1600 Amphitheatre Parkway, Mountain View, CA'
}, function(err, response) {
  if (!err) {
    console.log(response.json.results);
  }
});
```
I wasn't sure if that was done on purpose, but I would be happy to fix that as well.

- Beau