### PR TITLE
Add input data to output data.

### DIFF
--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -106,6 +106,9 @@ exports.inject = function(options) {
     var task =
         Task.race([timeoutTask, requestTask])
         .thenDo(function(response) {
+          response.requestUrl = requestUrl;
+          response.query = query;
+
           if (response.status === 200 && (
                   response.json.status === 'OK' ||
                   response.json.status === 'ZERO_RESULTS')) {

--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -106,6 +106,8 @@ exports.inject = function(options) {
     var task =
         Task.race([timeoutTask, requestTask])
         .thenDo(function(response) {
+          // We add the request url and the original query to the reponse
+          // to be able to use them when debugging errors.
           response.requestUrl = requestUrl;
           response.query = query;
 


### PR DESCRIPTION
As mentioned in #88 I wanted a way to return all the settings and data that is used to query a particular API, for debugging these calls. Although the solution in the mention issues works, I think it's not perfect. When I just copy the `makeUrlRequest` code and change it for my project I don't get any bug fixes or new features from the module in this library. So I thought I try to figure out how everyone would win.

I updated the `makeApiCall` method to return not only the response from a particular API but also the values that were given to that API.

Hope that would fit into the lib which we use quite often now.