### PR TITLE
Cleanup NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "jsdoc": "^3.4.0",
     "priorityqueuejs": "^1.0.0",
     "q": "^1.4.1"
-  }
+  },
+  "files": ["lib", "bin"]
 }


### PR DESCRIPTION
This change removes the following files/dirs from the NPM package:

- .npmignore
- .travis.yml
- docs
- spec

If you like to keep the docs I'll change the PR.