### PR TITLE
Use local https agent, instead of dirtying global agent

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -45,13 +45,12 @@ var agent = new https.Agent({ keepAlive: true });
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError) {
   var options = parse(url);
-  options.method = 'GET';
   options.agent = agent;
   options.headers = {
     'User-Agent': 'GoogleGeoApiClientJS/' + version
   };
 
-  var request = https.request(options, function(response) {
+  var request = https.get(options, function(response) {
 
     response.on('error', function(error) {
       onError(error)
@@ -83,8 +82,6 @@ module.exports = function makeUrlRequest(url, onSuccess, onError) {
   }).on('error', function(error) {
     onError(error)
   });
-
-  request.end();
 
   return function cancel() { request.abort(); };
 };

--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -21,7 +21,7 @@ var version = require('../version');
 
 
 // add keep-alive header to speed up request
-https.globalAgent.keepAlive = true;
+var agent = new https.Agent({ keepAlive: true });
 
 
 /**
@@ -45,11 +45,13 @@ https.globalAgent.keepAlive = true;
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError) {
   var options = parse(url);
+  options.method = 'GET';
+  options.agent = agent;
   options.headers = {
     'User-Agent': 'GoogleGeoApiClientJS/' + version
   };
 
-  var request = https.get(options, function(response) {
+  var request = https.request(options, function(response) {
 
     response.on('error', function(error) {
       onError(error)
@@ -81,6 +83,8 @@ module.exports = function makeUrlRequest(url, onSuccess, onError) {
   }).on('error', function(error) {
     onError(error)
   });
+
+  request.end();
 
   return function cancel() { request.abort(); };
 };


### PR DESCRIPTION
The commit before sets `https.globalAgent.keepAlive = true`, which was very dangerous, because this dirties other modules that rely on `https` module. For instance, it messes up some of Stripe's consecutive requests.

This commits give google map its own local agent (request pool), thus no conflicts with other modules.