### PR TITLE
Exclude false values from params

### DIFF
--- a/lib/internal/validate.js
+++ b/lib/internal/validate.js
@@ -51,10 +51,6 @@ Validate.that = function(predicate, message) {
   };
 };
 
-Validate.boolean = Validate.that(function(value) {
-  return typeof value === 'boolean';
-}, 'not a boolean');
-
 Validate.number = Validate.that(function(value) {
   return typeof value === 'number';
 }, 'not a number');
@@ -83,7 +79,7 @@ Validate.object = function(propertyValidators) {
           throw new InvalidValueError('missing property "' + key + '"');
         }
       }
-      if (key in object || valid !== undefined) {
+      if (key in object && valid !== undefined) {
         result[key] = valid;
       }
     }
@@ -165,3 +161,12 @@ Validate.compose = function(validators) {
     return value;
   };
 };
+
+Validate.boolean = Validate.compose([
+  Validate.that(function(value) {
+    return typeof value === 'boolean';
+  }, 'not a boolean'),
+  function(value) {
+    return value ? value : undefined;
+  }
+]);


### PR DESCRIPTION
@stephenfarrar PTAL

This changes boolean validation to only return its value when true - all of the bool params in the APIs default to false, and several of them (all the ones I checked) treat the presence of any value as true, so when false we want to drop it entirely.

For this change to work I also made a change which I think is a bugfix but wanted you to triple-check for me, the line `if (key in object && valid !== undefined) {`