### PR TITLE
Added example of promise constructor

### DIFF
--- a/docs/HOME.md
+++ b/docs/HOME.md
@@ -58,6 +58,12 @@ NOTE: Promises are only available if you supply a
 constructor to the [`createClient()`](module-@google_maps.html#.createClient) method. You must also chain `.asPromise()` to a method before any `.then()` or `.catch()` methods.
 For example: 
 ```js
+// Create client with a Promise constructor
+const googleMapsClient = require('@google/maps').createClient({
+  key: 'your API key here',
+  Promise: Promise // 'Promise' is the native constructor.
+});
+
 // Geocode an address with a promise
 googleMapsClient.geocode({address: '1600 Amphitheatre Parkway, Mountain View, CA'}).asPromise()
   .then((response) => {


### PR DESCRIPTION
Addresses #99 

I opted not to use ES6 shorthand here, as I think it's nicer to make clear that the property name is 'Promise'.

If it's not clear enough, I'm happy to also add an example of using Bluebird or another Promise library.