### PR TITLE
Fix JSDoc for geocode bounds parameter

### DIFF
--- a/lib/apis/geocode.js
+++ b/lib/apis/geocode.js
@@ -27,8 +27,10 @@ var v = require('../internal/validate');
  * @param {string} [query.address]
  * @param {Object} [query.components]
  * @param {Object} [query.bounds]
- * @param {LatLng} query.bounds.southwest
- * @param {LatLng} query.bounds.northeast
+ * @param {number} query.bounds.south
+ * @param {number} query.bounds.west
+ * @param {number} query.bounds.north
+ * @param {number} query.bounds.east
  * @param {string} [query.region]
  * @param {string} [query.language]
  * @param {ResponseCallback} callback Callback function for handling the result


### PR DESCRIPTION
`bounds` parameter structure was modified by 8c51daba69c43c8b2aac547e1fb7ad84d70db047.  
Issue #78 was possibly caused by this discrepancy.

*It is also unclear why bounds parameter structure was changed at all when adding those tests. google-maps-services libraries for other languages still use an interface with `southwest` and `northeast`.*

