### PR TITLE
utils.pipedKeyValues: support piped values to allow multiple values of same property

### DIFF
--- a/lib/internal/convert.js
+++ b/lib/internal/convert.js
@@ -26,7 +26,9 @@ exports.pipedKeyValues = function(arg) {
     throw new v.InvalidValueError('not an Object');
   }
   return Object.keys(arg).sort().map(function(key) {
-    return key + ':' + arg[key];
+    return arg[key].split('|').map(function(val) {
+      return key + ':' + val;
+    }).join('|');
   }).join('|');
 };
 


### PR DESCRIPTION
Fix #128 
Still only accept object as `components` param type, but allow piped values to create multiple properties with same key.

E.g. 
`components: { country: 'us|sv' }`
generates:
`components=country:us|country:sv`