### PR TITLE
Add region parameter to Text Search API

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -33,6 +33,7 @@ var v = require('../internal/validate');
  * @param {boolean} [query.opennow]
  * @param {string} [query.type]
  * @param {string} [query.pagetoken]
+ * @param {string} [query.region]
  * @param {ResponseCallback} callback Callback function for handling the result
  * @return {RequestHandle}
  */
@@ -49,7 +50,8 @@ exports.places = {
     type: v.optional(v.string),
     pagetoken: v.optional(v.string),
     retryOptions: v.optional(utils.retryOptions),
-    timeout: v.optional(v.number)
+    timeout: v.optional(v.number),
+    region: v.optional(v.string)
   })
 };
 


### PR DESCRIPTION
With this change client.places() can accept the region parameter.