### PR TITLE
Allow customParams to overwrite query options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@
       // Merge query and customParams.
       var finalQuery = {};
       customParams = customParams || {};
-      [customParams, query].map(function(obj) {
+      [query, customParams].map(function(obj) {
         Object.keys(obj).sort().map(function(key) {
           finalQuery[key] = obj[key];
         });


### PR DESCRIPTION
Currently it's not possible to overwrite for example `options.canRetry` by setting it in `customParams` because it gets overwritten by `query.options` which is always `undefined`.

This way around we provide a safe way to overwrite the whole options by using `customParams`.