### PR TITLE
Fix findPlace validation regex construction

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -51,7 +51,7 @@ exports.findPlace = {
       timeout: v.optional(v.number)
     }),
     function(query) {
-      var latLng = /^([-+]?\d{1,2}([.]\d+)?),*([-+]?\d{1,3}([.]\d+)?)$/;
+      var latLng = /([-+]?\d{1,2}([.]\d+)?),*([-+]?\d{1,3}([.]\d+)?)/;
       var parts = ['ipbias|point:', '|circle:([1-9]d*)+@', '|rectangle:', '\\|'];
       var re = new RegExp(parts.join(latLng.source), 'g');
       if (query.locationbias && !re.test(query.locationbias)) {


### PR DESCRIPTION
The regex does not match anything other than `ipbias`, since we've included line anchors in the `latLng` sub-regex. Removing line anchors seems to make it work.