### PR TITLE
Session token should be optional in AutoComplete

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -282,7 +282,7 @@ exports.placesAutoComplete = {
   url: 'https://maps.googleapis.com/maps/api/place/autocomplete/json',
   validator: v.object({
     input: v.string,
-    sessiontoken: v.string,
+    sessiontoken: v.optional(v.string),
     offset: v.optional(v.number),
     location: v.optional(utils.latLng),
     language: v.optional(v.string),


### PR DESCRIPTION
Session token is nullable in Autocomplete
https://developers.google.com/maps/documentation/javascript/places-autocomplete#session_tokens 