### PR TITLE
added proxy agent to work from within the enterprise network

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -18,6 +18,7 @@
 var https = require('https');
 var parse = require('url').parse;
 var version = require('../version');
+var HttpsProxyAgent = require('https-proxy-agent')
 
 
 // add keep-alive header to speed up request
@@ -46,6 +47,9 @@ var agent = new https.Agent({ keepAlive: true });
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
+  // HTTP/HTTPS proxy to connect from within the enterprise/corporate network
+  var proxy = process.env.http_proxy || process.env.https_proxy
+
   var requestOptions = parse(url);
   var body;
 
@@ -63,6 +67,10 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
   requestOptions.headers = requestOptions.headers || {};
   requestOptions.headers['User-Agent'] = 'GoogleGeoApiClientJS/' + version;
+
+  // create an instance of the `HttpsProxyAgent` class with the proxy server information
+  var proxyAgent = new HttpsProxyAgent(proxy)
+  requestOptions.agent = proxyAgent
 
   var request = https.request(requestOptions, function(response) {
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://github.com/googlemaps/google-maps-services-js",
   "dependencies": {
-    "uuid": ">=2.2.1"
+    "uuid": ">=2.2.1",
+    "https-proxy-agent": "^2.2.1"
   },
   "devDependencies": {
     "jasmine": ">=2.3.2 <2.5.0",


### PR DESCRIPTION
Added a dependency package "https-proxy-agent" which is instantiated with any proxy maintained in the environment variable and passed to the proxy agent. I had to introduce this change to execute the request via. proxy.