### PR TITLE
added proxy agent for persuing the requests behind corporate proxy

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -18,6 +18,7 @@
 var https = require('https');
 var parse = require('url').parse;
 var version = require('../version');
+var HttpsProxyAgent = require('https-proxy-agent')
 
 
 // add keep-alive header to speed up request
@@ -46,6 +47,9 @@ var agent = new https.Agent({ keepAlive: true });
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
+  // HTTP/HTTPS proxy to connect from within the enterprise/corporate network
+  var proxy = process.env.http_proxy || process.env.https_proxy
+
   var requestOptions = parse(url);
   var body;
 
@@ -63,6 +67,10 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
   requestOptions.headers = requestOptions.headers || {};
   requestOptions.headers['User-Agent'] = 'GoogleGeoApiClientJS/' + version;
+
+  // create an instance of the `HttpsProxyAgent` class with the proxy server information
+  var proxyAgent = new HttpsProxyAgent(proxy)
+  requestOptions.agent = proxyAgent
 
   var request = https.request(requestOptions, function(response) {
 
@@ -114,3 +122,6 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
   return function cancel() { request.abort(); };
 };
+
+
+

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://github.com/googlemaps/google-maps-services-js",
   "dependencies": {
-    "uuid": ">=2.2.1"
+    "uuid": ">=2.2.1",
+    "https-proxy-agent": "^2.2.1"
   },
   "devDependencies": {
     "jasmine": ">=2.3.2 <2.5.0",
@@ -54,3 +55,4 @@
   },
   "files": ["lib", "bin"]
 }
+


### PR DESCRIPTION
Implemented https-proxy-agent library that connects to an intermediary "proxy" server and issues the CONNECT HTTP method, which tells the proxy to open a direct TCP connection to the destination server. This will help us to get the google maps client api to work from behind the corporate proxies.