### PR TITLE
added https proxy agent for pursuing the requests behind corporate proxy

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -46,9 +46,6 @@ var agent = new https.Agent({ keepAlive: true });
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
-  // HTTP/HTTPS proxy to connect from within the enterprise/corporate network
-  var proxy = process.env.http_proxy || process.env.https_proxy
-
   var requestOptions = parse(url);
   var body;
 
@@ -67,9 +64,14 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
   requestOptions.headers = requestOptions.headers || {};
   requestOptions.headers['User-Agent'] = 'GoogleGeoApiClientJS/' + version;
 
-  // create an instance of the `HttpsProxyAgent` class with the proxy server information
-  var proxyAgent = new HttpsProxyAgent(proxy)
-  requestOptions.agent = proxyAgent
+  // HTTP/HTTPS proxy to connect from within the enterprise/corporate network
+  var proxy = process.env.http_proxy || process.env.https_proxy
+
+  if (proxy) {
+    // create an instance of the `HttpsProxyAgent` class with the proxy server information
+    var proxyAgent = new HttpsProxyAgent(proxy)
+    requestOptions.agent = proxyAgent
+  }
 
   var request = https.request(requestOptions, function (response) {
 

--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -18,7 +18,7 @@
 var https = require('https');
 var parse = require('url').parse;
 var version = require('../version');
-
+var HttpsProxyAgent = require('https-proxy-agent');
 
 // add keep-alive header to speed up request
 var agent = new https.Agent({ keepAlive: true });
@@ -46,6 +46,9 @@ var agent = new https.Agent({ keepAlive: true });
  */
 module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
 
+  // HTTP/HTTPS proxy to connect from within the enterprise/corporate network
+  var proxy = process.env.http_proxy || process.env.https_proxy
+
   var requestOptions = parse(url);
   var body;
 
@@ -64,9 +67,13 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
   requestOptions.headers = requestOptions.headers || {};
   requestOptions.headers['User-Agent'] = 'GoogleGeoApiClientJS/' + version;
 
-  var request = https.request(requestOptions, function(response) {
+  // create an instance of the `HttpsProxyAgent` class with the proxy server information
+  var proxyAgent = new HttpsProxyAgent(proxy)
+  requestOptions.agent = proxyAgent
 
-    response.on('error', function(error) {
+  var request = https.request(requestOptions, function (response) {
+
+    response.on('error', function (error) {
       onError(error);
     });
 
@@ -77,10 +84,10 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
     } else if (response.headers['content-type'] == 'application/json; charset=UTF-8') {
       // Handle JSON.
       var data = [];
-      response.on('data', function(chunk) {
+      response.on('data', function (chunk) {
         data.push(chunk);
       });
-      response.on('end', function() {
+      response.on('end', function () {
         var json;
         try {
           json = JSON.parse(Buffer.concat(data).toString());
@@ -102,7 +109,7 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
       onSuccess(response);
     }
 
-  }).on('error', function(error) {
+  }).on('error', function (error) {
     onError(error);
   });
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "homepage": "https://github.com/googlemaps/google-maps-services-js",
   "dependencies": {
+    "https-proxy-agent": "^2.2.1",
     "uuid": ">=2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Implemented https-proxy-agent library that connects to an intermediary "proxy" server and issues the CONNECT HTTP method, which tells the proxy to open a direct TCP connection to the destination server. This will help us to get the google maps client api to work from behind the corporate proxies.