### PR TITLE
fixes pagination INVALID_REQUEST handling

### DIFF
--- a/lib/internal/make-api-call.js
+++ b/lib/internal/make-api-call.js
@@ -86,7 +86,7 @@ exports.inject = function(options) {
     }
 
     // Determines whether a response indicates a retriable error.
-    var canRetry = queryOptions.canRetry || function(response) {
+    var canRetry = queryOptions.canRetry || function(response, query) {
       return (
         response == null
         || response.status === 500
@@ -94,7 +94,8 @@ exports.inject = function(options) {
         || response.status === 504
         || (response.json && (
             response.json.status === 'OVER_QUERY_LIMIT' ||
-            response.json.status === 'RESOURCE_EXHAUSTED')));
+            response.json.status === 'RESOURCE_EXHAUSTED' ||
+            (response.json.status ===  'INVALID_REQUEST'  && query.pagetoken))));
     };
     delete queryOptions.canRetry;
 
@@ -121,7 +122,7 @@ exports.inject = function(options) {
     });
     var requestTask = attempt({
       'do': rateLimitedGet,
-      until: function(response) { return !canRetry(response); },
+      until: function(response) { return !canRetry(response, query); },
       interval: retryOptions.interval,
       increment: retryOptions.increment,
       jitter: retryOptions.jitter

--- a/spec/e2e/places-spec.js
+++ b/spec/e2e/places-spec.js
@@ -117,7 +117,7 @@ describe('places client library', function() {
               setTimeout(resolve, 2000);
             })
             .then(getNextPage)
-            // .then(repeatWhileInvalid);
+            .then(repeatWhileInvalid);
           });
     })
     .then(function(nextResponse) {      


### PR DESCRIPTION
When a next_page_token is returned for nearby places searches,  an INVALID_REQUEST status is returned if the token is sent too quickly. This fixes retry logic for this case, and reenables a pagination test that  was  previously failing  because of this.