### PR TITLE
docs: Add npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Node.js Client for Google Maps Services
 =======================================
 
-[![Build Status](https://travis-ci.org/googlemaps/google-maps-services-js.svg?branch=master)](https://travis-ci.org/googlemaps/google-maps-services-js)
+[![Build Status](https://travis-ci.org/googlemaps/google-maps-services-js.svg?branch=master)](https://travis-ci.org/googlemaps/google-maps-services-js)  [![npm](https://img.shields.io/npm/v/@google/maps.svg)](https://www.npmjs.com/package/@google/maps)
 
 Use Node.js? Want to [geocode][Geocoding API] something? Looking
 for [directions][Directions API]?


### PR DESCRIPTION
Adds a README npm badge so that users can go directly to npm.

[![npm](https://img.shields.io/npm/v/@google/maps.svg)](https://www.npmjs.com/package/@google/maps)