### PR TITLE
Add the "origin" parameter to the placesAutoComplete function

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -272,6 +272,7 @@ exports.placesPhoto = {
  * @param {LatLng} [query.location]
  * @param {string} [query.language]
  * @param {number} [query.radius]
+ * @param {string} [query.origin]
  * @param {string} [query.types]
  * @param {Object} components
  * @param {boolean} [query.strictbounds]
@@ -287,6 +288,7 @@ exports.placesAutoComplete = {
     location: v.optional(utils.latLng),
     language: v.optional(v.string),
     radius: v.optional(v.number),
+    origin: v.optional(v.string),
     types: v.optional(v.oneOf(['geocode', 'address', 'establishment', '(regions)', '(cities)'])),
     components: v.optional(utils.pipedKeyValues),
     strictbounds: v.optional(v.boolean),


### PR DESCRIPTION
Without passing the `origin` parameter to the `placesAutoComplete()` function we can't get the distance of the result items from our specified location. 
(`result.json.predictions[n]distance_meters` in the response).