### PR TITLE
Allow custom parameters to override defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@
       // Merge query and customParams.
       var finalQuery = {};
       customParams = customParams || {};
-      [customParams, query].map(function(obj) {
+      [query, customParams].map(function(obj) {
         Object.keys(obj).sort().map(function(key) {
           finalQuery[key] = obj[key];
         });


### PR DESCRIPTION
I've had the same problem as https://github.com/googlemaps/google-maps-services-js/issues/196 in which a quota-exceeded failure wouldn't bubble up to my callback and I would have to wait for the whole timeout before getting a response. Also, setting a short timeout isn't an interesting option as the initial error would not bubble up either. The best thing to do would be to override `canRetry`  and setting it to a function that returns false in order to bypass the retry mechanism and receive an error. This is the behavior I wanted.

I noticed that the `customParams` object was passed second instead of first, so anything put in there would be overwritten by the default params.

This fixes it and allows customParams to overwrite default params.