### PR TITLE
Check content-type without significance of case-sensitivity

### DIFF
--- a/lib/internal/make-url-request.js
+++ b/lib/internal/make-url-request.js
@@ -83,7 +83,7 @@ module.exports = function makeUrlRequest(url, onSuccess, onError, options) {
       // Handle redirect.
       var url = response.headers['location'];
       makeUrlRequest(url, onSuccess, onError, options);
-    } else if (response.headers['content-type'] == 'application/json; charset=UTF-8') {
+    } else if (response.headers['content-type'].toLowerCase() == 'application/json; charset=utf-8') {
       // Handle JSON.
       var data = [];
       response.on('data', function (chunk) {


### PR DESCRIPTION
Hi!

In a test environment, I am mocking google maps HTTP request and returns results for directions API requests.
In my responses, I return the header of `Content-Type` with `utf-8` lowercase and I can't change since it's hardcoded in the framework (express).

This PR changes the comparison not to be case-sensitive.