### PR TITLE
[BUG] fix `reviews` field name

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -225,7 +225,7 @@ exports.place = {
       'geometry', 'icon', 'id', 'name', 'permanently_closed', 'photo',
       'place_id', 'scope', 'type', 'url', 'utc_offset', 'vicinity',
       'formatted_phone_number', 'international_phone_number', 'opening_hours',
-      'website', 'price_level', 'rating', 'review', 'user_ratings_total', 'plus_code'
+      'website', 'price_level', 'rating', 'reviews', 'user_ratings_total', 'plus_code'
     ]), ',')),
     retryOptions: v.optional(utils.retryOptions),
     timeout: v.optional(v.number)


### PR DESCRIPTION
Fixes misspelling in field name validation - it must be `reviews`, not `review`: https://developers.google.com/places/web-service/place-data-fields