### PR TITLE
fix: findPlace should allow user_ratings_total as field

### DIFF
--- a/lib/apis/places.js
+++ b/lib/apis/places.js
@@ -48,7 +48,8 @@ exports.findPlace = {
         'geometry/viewport/southwest', 'geometry/viewport/southwest/lat',
         'geometry/viewport/southwest/lng', 'icon', 'id', 'name',
         'permanently_closed', 'photos', 'place_id', 'scope', 'types',
-        'vicinity', 'opening_hours', 'price_level', 'rating', 'plus_code'
+        'vicinity', 'opening_hours', 'price_level', 'rating', 'user_ratings_total',
+        'plus_code'
       ]), v.deprecate(["alt_id", "id", "reference", "scope"])]), ',')),
       locationbias: v.optional(v.string),
       retryOptions: v.optional(utils.retryOptions),


### PR DESCRIPTION
According to https://developers.google.com/places/web-service/search#Fields the user_ratings_total field is allowed under atmosphere fields but this is being blocked incorrectly by the validator.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
