### PR TITLE
fix: Support a Status of ZERO_RESULTS

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -66,7 +66,9 @@ export type Status =
   /** indicates that the service denied use of the Distance Matrix service by your application. */
   | "REQUEST_DENIED"
   /** indicates a Distance Matrix request could not be processed due to a server error. The request may succeed if you try again. */
-  | "UNKNOWN_ERROR";
+  | "UNKNOWN_ERROR"
+  /** indicates that the request was successful but returned no results. */
+  | "ZERO_RESULTS";
 
 export interface PlacePhoto {
   /** a string used to identify the photo when you perform a Photo request. */


### PR DESCRIPTION
This is a common response type. In my case I was writing the following:
```
const gmapsResult = await googleMapsClient.placeQueryAutocomplete({
        params: {
          input: keyphrase,
          key: process.env.GOOGLE_MAPS_API_KEY,
        },
      });
      if (gmapsResult.data.status === "ZERO_RESULTS") { // TypeScript error.

      }
```
when the actual response from the API was in fact the "ZERO_RESULTS" response as documented at https://developers.google.com/places/web-service/query#query_autocomplete_status_codes

In the interim I worked around the TypeScript error by coercing the status to string and then comparing.