### PR TITLE
feat: Request gzip response compression by default

### DIFF
--- a/e2e/compression.test.ts
+++ b/e2e/compression.test.ts
@@ -1,0 +1,29 @@
+import { directions } from "../src/directions";
+
+test("server responds with compressed content", async () => {
+  const params = {
+    origin: "Seattle, WA",
+    destination: "San Francisco, CA",
+    waypoints: [{ lat: 40, lng: -120 }],
+    key: process.env.GOOGLE_MAPS_API_KEY
+  };
+
+  // Use of directions here is entirely arbitrary and any API that supports
+  // result compression could be substituted.
+
+  const r = await directions({ params: params });
+  expect(r.data.status).toEqual("OK");
+
+  // Axios removes conent-encoding from the response header set once it takes
+  // care of piping the stream through a zlib unzip instance.  So verifying
+  // that the server responds with a compressed response must be done via the
+  // raw headers.
+
+  const {rawHeaders} = r.request.res;
+  const contentEncodingIndex = rawHeaders
+      .findIndex(i => i.toLowerCase() === "content-encoding");
+
+  expect(contentEncodingIndex).not.toBe(-1);
+  expect(rawHeaders[contentEncodingIndex + 1]).toBe("gzip");
+  expect(r.headers["Content-Encoding"]).toBeUndefined();
+});

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,6 +1,7 @@
 import {
   Client,
   userAgent,
+  acceptEncoding,
   DirectionsRequest,
   DistanceMatrixRequest,
   ElevationRequest,
@@ -38,6 +39,7 @@ test("client can be instantiated with axiosInstance has correct defaults", () =>
   expect(client["axiosInstance"].defaults.headers["User-Agent"]).toEqual(
     userAgent
   );
+  expect(client["axiosInstance"].defaults.headers["Accept-Encoding"]).toBeUndefined();
   expect(client["axiosInstance"].defaults.timeout).toEqual(
     axios.defaults.timeout
   );
@@ -59,6 +61,21 @@ test("client can be instantiated with header options", () => {
   expect(client["axiosInstance"].defaults.headers["User-Agent"]).toEqual(
     userAgent
   );
+  expect(client["axiosInstance"].defaults.headers["Accept-Encoding"]).toBe(
+      acceptEncoding
+  );
+});
+
+test("client can be override Accept-Encoding with header options", () => {
+  const client = new Client({ config: { headers: { "x-foo": "bar", "Accept-Encoding": "identity" } } });
+  expect(client["axiosInstance"]).toBeDefined();
+  expect(client["axiosInstance"].defaults.headers["x-foo"]).toEqual("bar");
+  expect(client["axiosInstance"].defaults.headers["User-Agent"]).toEqual(
+      userAgent
+  );
+  expect(client["axiosInstance"].defaults.headers["Accept-Encoding"]).toBe(
+      "identity"
+  );
 });
 
 test("client can be instantiated without header options", () => {
@@ -67,6 +84,9 @@ test("client can be instantiated without header options", () => {
   expect(client["axiosInstance"].defaults.timeout).toEqual(1234);
   expect(client["axiosInstance"].defaults.headers["User-Agent"]).toEqual(
     userAgent
+  );
+  expect(client["axiosInstance"].defaults.headers["Accept-Encoding"]).toBe(
+      acceptEncoding
   );
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,12 +70,16 @@ import {
 export const defaultHttpsAgent = new HttpsAgent({ keepAlive: true });
 export const defaultTimeout = 10000;
 export const userAgent = `google-maps-services-node-${version}`;
+export const acceptEncoding = "gzip";
 export const X_GOOG_MAPS_EXPERIENCE_ID = "X-GOOG-MAPS-EXPERIENCE-ID";
 
 const defaultConfig = {
   timeout: defaultTimeout,
   httpsAgent: defaultHttpsAgent,
-  headers: { "User-Agent": userAgent }
+  headers: {
+    "User-Agent": userAgent,
+    "Accept-Encoding": acceptEncoding
+  }
 };
 
 export const defaultAxiosInstance = axios.create(defaultConfig);


### PR DESCRIPTION
Adds an "Accept-Encoding: gzip" header to all requests to improve
transfer speed and bandwidth utilization via server response
compression.

Most (all?) of the Maps APIs support serving compressed content and
this library's HTTP client (Axios) will transparently handle
decompression.

Requesting compressed content is already the default behavior of the Go
and Java google-maps-services client libraries.

A user can opt-out of compression by specifying a custom
Accept-Encoding ("identity") via config.headers at Client instantiation
or by instantiating a Client with an Axios client.

Fixes #356 
