### PR TITLE
fix: export common at root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,4 +52,5 @@ export { SnapToRoadsRequest, SnapToRoadsResponse } from "./roads/snaptoroads";
 export { TextSearchRequest, TextSearchResponse } from "./places/textsearch";
 export { TimeZoneRequest, TimeZoneResponse } from "./timezone";
 
+export * from "./common";
 export * from "./client";


### PR DESCRIPTION
This should make it easier to use the enums.