### PR TITLE
fix: Add NOT_FOUND to the status enum according to documentation

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -85,6 +85,8 @@ export enum Status {
   UNKNOWN_ERROR = "UNKNOWN_ERROR",
   /** indicates that the request was successful but returned no results. */
   ZERO_RESULTS = "ZERO_RESULTS",
+  /** indicates that the referenced location (place_id) was not found in the Places database. */
+  NOT_FOUND = "NOT_FOUND",
 }
 
 export interface PlacePhoto {


### PR DESCRIPTION
Fixes #404 

According to the documentation [here](https://developers.google.com/places/web-service/details#PlaceDetailsStatusCodes), the status `NOT_FOUND` is a valid response the API might return.

Added it to the `Status` enum.
