### PR TITLE
fix!: use custom http adapter to set status code and reject

### DIFF
--- a/e2e/client.test.ts
+++ b/e2e/client.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { Client, defaultAxiosInstance, defaultHttpsAgent } from "../src";
+import { AxiosError } from "axios";
 
 test("client should work with defaults", async () => {
   const location = { lat: 10, lng: 20 };
@@ -61,7 +62,7 @@ test("readme example using client", async () => {
   const { Client, Status } = require("../src");
   const client = new Client({});
 
-  client
+  await client
     .elevation({
       params: {
         locations: [{ lat: 45, lng: -110 }],
@@ -84,7 +85,7 @@ test("readme example using client fails correctly", async () => {
   const { Client, Status } = require("../src");
   const client = new Client({});
 
-  client
+  await client
     .elevation({
       params: {
         locations: [{ lat: 45, lng: -110 }],
@@ -92,11 +93,8 @@ test("readme example using client fails correctly", async () => {
       },
       timeout: 1000, // milliseconds
     })
-    .then((r) => {
-      expect(r.data.status).toEqual(Status.REQUEST_DENIED);
-    })
-    .catch((e) => {
-      console.log(e);
-      throw "Should not error";
+    .catch((e: AxiosError) => {
+      expect(e.response.status).toEqual(403);
+      expect(e.response.data.status).toEqual(Status.REQUEST_DENIED);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7348,6 +7348,18 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -11395,6 +11407,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^12.12.15",
     "codecov": ">=3.6.5",
     "jest": "^25.2.2",
+    "nock": "^12.0.3",
     "semantic-release": "^17.0.2",
     "ts-jest": "^25.2.1",
     "typedoc": "^0.16.11",

--- a/src/adapter.test.ts
+++ b/src/adapter.test.ts
@@ -78,4 +78,5 @@ test("statusToCode returns correct value", () => {
   expect(statusToCode(Status.OVER_DAILY_LIMIT)).toEqual(429);
   expect(statusToCode(Status.OVER_QUERY_LIMIT)).toEqual(429);
   expect(statusToCode(Status.UNKNOWN_ERROR)).toEqual(500);
+  expect(statusToCode("foo" as Status)).toEqual(200);
 });

--- a/src/adapter.test.ts
+++ b/src/adapter.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { statusToCode } from "./adapter";
+import { Status } from "./common";
+import * as nock from "nock";
+import { Client } from "./client";
+import { AxiosResponse } from "axios";
+
+nock.disableNetConnect();
+
+test("httpadapter rejects Status.NOT_FOUND", async () => {
+  nock("https://maps.googleapis.com")
+    .get(
+      "/maps/api/place/details/json?fields=place_id,name&key=foo&place_id=notarealid"
+    )
+    .reply(200, JSON.stringify({ status: Status.NOT_FOUND }), {
+      "Content-Type": "application/json",
+    });
+
+  const client = new Client();
+
+  const params = {
+    place_id: "notarealid",
+    key: "foo",
+    fields: ["place_id", "name"],
+  };
+
+  await expect(client.placeDetails({ params: params })).rejects.toEqual(
+    Error("Request failed with status code 404")
+  );
+});
+
+test("httpadapter resolves Status.OK", async () => {
+  const response = { status: Status.OK };
+
+  nock("https://maps.googleapis.com")
+    .get(
+      "/maps/api/place/details/json?fields=place_id,name&key=foo&place_id=notarealid"
+    )
+    .reply(200, JSON.stringify(response), {
+      "Content-Type": "application/json",
+    });
+
+  const client = new Client();
+
+  const params = {
+    place_id: "notarealid",
+    key: "foo",
+    fields: ["place_id", "name"],
+  };
+
+  const r: AxiosResponse = await client.placeDetails({ params: params });
+  expect(r.data).toEqual(response);
+});
+
+test("statusToCode returns correct value", () => {
+  expect(statusToCode(Status.OK)).toEqual(200);
+  expect(statusToCode(Status.ZERO_RESULTS)).toEqual(200);
+  expect(statusToCode(Status.INVALID_REQUEST)).toEqual(400);
+  expect(statusToCode(Status.MAX_ROUTE_LENGTH_EXCEEDED)).toEqual(400);
+  expect(statusToCode(Status.MAX_WAYPOINTS_EXCEEDED)).toEqual(400);
+  expect(statusToCode(Status.REQUEST_DENIED)).toEqual(403);
+  expect(statusToCode(Status.NOT_FOUND)).toEqual(404);
+  expect(statusToCode(Status.OVER_DAILY_LIMIT)).toEqual(429);
+  expect(statusToCode(Status.OVER_QUERY_LIMIT)).toEqual(429);
+  expect(statusToCode(Status.UNKNOWN_ERROR)).toEqual(500);
+});

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,0 +1,50 @@
+import * as settle from "axios/lib/core/settle";
+import * as defaults from "axios/lib/defaults";
+import * as transformData from "axios/lib/core/transformData";
+import { Status } from "./common";
+import { AxiosRequestConfig, AxiosResponse, AxiosPromise } from "axios";
+
+export function statusToCode(status: Status): number {
+  switch (status) {
+    case Status.OK:
+    case Status.ZERO_RESULTS: {
+      return 200;
+    }
+    case Status.INVALID_REQUEST:
+    case Status.MAX_ROUTE_LENGTH_EXCEEDED:
+    case Status.MAX_WAYPOINTS_EXCEEDED: {
+      return 400;
+    }
+    case Status.REQUEST_DENIED: {
+      return 403;
+    }
+    case Status.NOT_FOUND: {
+      return 404;
+    }
+    case Status.OVER_DAILY_LIMIT:
+    case Status.OVER_QUERY_LIMIT: {
+      return 429;
+    }
+    case Status.UNKNOWN_ERROR: {
+      return 500;
+    }
+    default: {
+      return 200;
+    }
+  }
+}
+
+export const customAdapter = (config: AxiosRequestConfig): AxiosPromise<any> =>
+  new Promise((resolve, reject) => {
+    defaults
+      .adapter(config)
+      .then((r: AxiosResponse) => {
+        // unfortunately data is transformed after the adapter
+        r.data = transformData(r.data, r.headers, config.transformResponse);
+        if (r.status === 200 && r.data.status) {
+          r.status = statusToCode(r.data.status);
+        }
+        settle(resolve, reject, r);
+      })
+      .catch(reject);
+  });

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as settle from "axios/lib/core/settle";
 import * as defaults from "axios/lib/defaults";
 import * as transformData from "axios/lib/core/transformData";

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,71 +19,72 @@ import * as rax from "retry-axios";
 import {
   DirectionsRequest,
   DirectionsResponse,
-  directions
+  directions,
 } from "./directions";
 import {
   DistanceMatrixRequest,
   DistanceMatrixResponse,
-  distancematrix
+  distancematrix,
 } from "./distance";
 import { ElevationRequest, ElevationResponse, elevation } from "./elevation";
 import {
   FindPlaceFromTextRequest,
   FindPlaceFromTextResponse,
-  findPlaceFromText
+  findPlaceFromText,
 } from "./places/findplacefromtext";
 import { GeocodeRequest, GeocodeResponse, geocode } from "./geocode/geocode";
 import { GeolocateRequest, GeolocateResponse, geolocate } from "./geolocate";
 import {
   NearestRoadsRequest,
   NearestRoadsResponse,
-  nearestRoads
+  nearestRoads,
 } from "./roads/nearestroads";
 import {
   PlaceAutocompleteRequest,
   PlaceAutocompleteResponse,
-  placeAutocomplete
+  placeAutocomplete,
 } from "./places/autocomplete";
 import {
   PlaceDetailsRequest,
   PlaceDetailsResponse,
-  placeDetails
+  placeDetails,
 } from "./places/details";
 import {
   PlacePhotoRequest,
   PlacePhotoResponse,
-  placePhoto
+  placePhoto,
 } from "./places/photo";
 import {
   PlaceQueryAutocompleteRequest,
   PlaceQueryAutocompleteResponse,
-  placeQueryAutocomplete
+  placeQueryAutocomplete,
 } from "./places/queryautocomplete";
 import {
   PlacesNearbyRequest,
   PlacesNearbyResponse,
-  placesNearby
+  placesNearby,
 } from "./places/placesnearby";
 import {
   ReverseGeocodeRequest,
   ReverseGeocodeResponse,
-  reverseGeocode
+  reverseGeocode,
 } from "./geocode/reversegeocode";
 import {
   SnapToRoadsRequest,
   SnapToRoadsResponse,
-  snapToRoads
+  snapToRoads,
 } from "./roads/snaptoroads";
 import {
   TextSearchRequest,
   TextSearchResponse,
-  textSearch
+  textSearch,
 } from "./places/textsearch";
 import { TimeZoneRequest, TimeZoneResponse, timezone } from "./timezone";
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 
 import { HttpsAgent } from "agentkeepalive";
 import { version } from "./index";
+import { customAdapter } from "./adapter";
 
 export const defaultHttpsAgent = new HttpsAgent({ keepAlive: true });
 export const defaultTimeout = 10000;
@@ -91,13 +92,14 @@ export const userAgent = `google-maps-services-node-${version}`;
 export const acceptEncoding = "gzip";
 export const X_GOOG_MAPS_EXPERIENCE_ID = "X-GOOG-MAPS-EXPERIENCE-ID";
 
-const defaultConfig = {
+const defaultConfig: AxiosRequestConfig = {
   timeout: defaultTimeout,
   httpsAgent: defaultHttpsAgent,
+  adapter: customAdapter,
   headers: {
     "User-Agent": userAgent,
-    "Accept-Encoding": acceptEncoding
-  }
+    "Accept-Encoding": acceptEncoding,
+  },
 };
 
 export const defaultAxiosInstance = axios.create(defaultConfig);
@@ -115,19 +117,19 @@ export interface ClientOptions {
   experienceId?: string[];
 }
 /**
- * Client is a light wrapper around API methods providing shared configuration for Axios 
+ * Client is a light wrapper around API methods providing shared configuration for Axios
  * settings such as retry logic using the default retry-axios settings and gzip encoding.
- * 
+ *
  * ### Instantiate with defaults
  * ```
  * const client = Client()
  * ```
- * 
+ *
  * ### Instantiate with config
  * ```
  * const client = Client({config})
  * ```
- * 
+ *
  * ### Instantiate with axiosInstance **Advanced**
  * ```
  * const axiosInstance = axios.create(config)
@@ -147,7 +149,7 @@ export class Client {
       this.axiosInstance = axiosInstance;
       this.axiosInstance.defaults.headers = {
         ...defaultConfig.headers,
-        ...this.axiosInstance.defaults.headers
+        ...this.axiosInstance.defaults.headers,
       };
     } else if (config) {
       config = { ...defaultConfig, ...config };
@@ -286,5 +288,5 @@ export {
   TextSearchRequest,
   TextSearchResponse,
   TimeZoneRequest,
-  TimeZoneResponse
+  TimeZoneResponse,
 };


### PR DESCRIPTION
close #393 

BREAKING CHANGE: responses that previously returned a 200 with a non OK status and resolved will now reject with something other than 200.

From a test case:

```js
await client
    .elevation({
      params: {
        locations: [{ lat: 45, lng: -110 }],
        key: "invalid key",
      },
      timeout: 1000, // milliseconds
    })
    .catch((e: AxiosError) => {
      expect(e.response.status).toEqual(403);
      expect(e.response.data.status).toEqual(Status.REQUEST_DENIED);
    });
});
```