### PR TITLE
fix: add new icon fields

### DIFF
--- a/e2e/places/details.test.ts
+++ b/e2e/places/details.test.ts
@@ -80,6 +80,8 @@ test("details should return all fields", async () => {
       "formatted_phone_number",
       "geometry",
       "icon",
+      "icon_background_color",
+      "icon_mask_base_uri",
       "international_phone_number",
       "name",
       "opening_hours",

--- a/e2e/places/placesnearby.test.ts
+++ b/e2e/places/placesnearby.test.ts
@@ -28,6 +28,8 @@ test("placesNearby should return correct result", async () => {
     Array [
       "geometry",
       "icon",
+      "icon_background_color",
+      "icon_mask_base_uri",
       "name",
       "photos",
       "place_id",

--- a/e2e/places/textsearch.test.ts
+++ b/e2e/places/textsearch.test.ts
@@ -30,6 +30,8 @@ test("textsearch should return correct result", async () => {
       "formatted_address",
       "geometry",
       "icon",
+      "icon_background_color",
+      "icon_mask_base_uri",
       "name",
       "photos",
       "place_id",

--- a/src/common.ts
+++ b/src/common.ts
@@ -457,11 +457,22 @@ interface PlaceData {
   plus_code: PlusCode;
   /** contains the URL of a suggested icon which may be displayed to the user when indicating this result on a map. */
   icon: string;
+  /** 
+   * The default HEX color code for the place's category. 
+   * @see https://developers.google.com/maps/documentation/places/web-service/icons
+   */
+  icon_background_color: string;
+  /** 
+   * The base URL for a non-colored icon, minus the file type extension (append `.svg` or `.png`).
+   * @see https://developers.google.com/maps/documentation/places/web-service/icons
+   */
+  icon_mask_base_uri: string;
   /**
    * contains the place's phone number in international format.
    * International format includes the country code, and is prefixed with the plus (+) sign.
    * For example, the `international_phone_number` for Google's Sydney, Australia office is `+61 2 9374 4000`.
    */
+  
   international_phone_number: string;
   /**
    * contains the human-readable name for the returned result.


### PR DESCRIPTION
Changes in https://developers.google.com/maps/documentation/places/web-service/icons, but that page has a typo where url should be uri. (Fixing that too!)