### PR TITLE
fix: use new version of @googlemaps/url-signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -443,9 +443,9 @@
       "dev": true
     },
     "@googlemaps/url-signature": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@googlemaps/url-signature/-/url-signature-1.0.3.tgz",
-      "integrity": "sha512-X19BrKR2cvC9XacyQVWzmVH7tKoOVlTE+Wfb5ookq3hs1OyJGfOt2eOKQ2+PkvU0r5ebBR0o9dCAH+Kf46HABw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@googlemaps/url-signature/-/url-signature-1.0.4.tgz",
+      "integrity": "sha512-9OPJzSi/1hz7ieDbdVCEIgpfIgdPyAA+EkOrbDXPsG81//TtrIiRS/0RrDCsG0d2UGcXBxMkZGF6Y1sbsMP7oA==",
       "requires": {
         "crypto-js": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:all": "jest"
   },
   "dependencies": {
-    "@googlemaps/url-signature": "^1.0.2",
+    "@googlemaps/url-signature": "^1.0.4",
     "agentkeepalive": "^4.1.0",
     "axios": "^0.24.0",
     "query-string": "^7.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,11 @@
         "target": "es6",
         "module": "commonjs",
         "outDir": "dist",
-        "sourceMap": true,
-        "types": [
-            "node",
-            "jest"
-        ],
+        "sourceMap": true,        
         "declaration": true,
         "declarationDir": "./dist",
         "resolveJsonModule": true,
-        "lib": ["ESNext"]
+        "lib": ["ESNext", "DOM"]
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
closes #702 using fix in https://github.com/googlemaps/js-url-signature/pull/28

kind of a mess in TS: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960