### PR TITLE
bump @googlemaps/url-signature from 1.0.21 to 1.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,9 +424,9 @@
       "dev": true
     },
     "@googlemaps/url-signature": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@googlemaps/url-signature/-/url-signature-1.0.21.tgz",
-      "integrity": "sha512-pRkDE5+8bewFrclQPvSihj2FwtAdGNtMz/keV4pxHyvsoJy1nb7cI5sxhitMzleJO6UGFsE0HxKqEofyhX550Q==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@googlemaps/url-signature/-/url-signature-1.0.24.tgz",
+      "integrity": "sha512-jN5/PUGwiyLUv0oJ1oAHIh0nFq3m2r8f4Bn08X5cQ2J3Tq3w1He852CrQ+ufGJiuV2KB/iVnxXpKuIUk7UOO9w==",
       "requires": {
         "crypto-js": "^4.1.1"
       }


### PR DESCRIPTION
url-signature-1.0.24 fixes an issue with source maps not being published.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #767
