### PR TITLE
fix: remove extra parenthesis from documentation example

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -221,7 +221,7 @@ export class Client {
    * const client = new Client();
    * client.geocode(args).then(gcResponse => {
    *   const str = JSON.stringify(gcResponse.data.results[0]);
-   *   console.log(`First result is: ${str}`);)
+   *   console.log(`First result is: ${str}`);
    * });
    * ```
    */


### PR DESCRIPTION
# Fixes issue #986 

This PR removes an extra `)` in one of the comments for geocoding. It was showing up in the auto-generated documentation.

Picture of what the wrong documentation looks like:
![image](https://github.com/googlemaps/google-maps-services-js/assets/22625481/21b4ec82-6f72-4808-b319-286da7e05efa)

What it will look like after this PR gets merged:
![image](https://github.com/googlemaps/google-maps-services-js/assets/22625481/3edbe0b1-508d-4c49-a34a-9c5a342119e2)


---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
