### PR TITLE
fix: add tests to prevent updating to esm-only dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,9 +2632,9 @@
       "dev": true
     },
     "retry-axios": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-3.1.0.tgz",
-      "integrity": "sha512-OQzlG/II3dXP6xocFk03zGgZC3GV/bVCYbMASY2SNDQWjbHktr6vws2N/HtEO+jKGMWas7BEBu3F5zwdf85ivw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+      "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ=="
     },
     "semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,13 @@
     "src"
   ],
   "scripts": {
+    "build": "tsc",
     "docs": "rm -rf docs/ && typedoc src/index.ts",
-    "prepack": "tsc",
-    "test": "jest src",
-    "test:e2e": "jest e2e",
+    "prepack": "npm run build",
+    "pretest": "npm run build",
+    "test": "jest ./src/* && npm run test:loading",
+    "test:loading": "./test-module-loading.sh",
+    "test:e2e": "jest ./e2e/*",
     "test:all": "jest"
   },
   "dependencies": {
@@ -48,7 +51,7 @@
     "agentkeepalive": "^4.1.0",
     "axios": "^1.5.1",
     "query-string": "<8.x",
-    "retry-axios": "<4"
+    "retry-axios": "<3.x"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",

--- a/test-module-loading.sh
+++ b/test-module-loading.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+failed=0
+
+cjsCode='const {Client} = require("./dist/"); new Client();'
+esmCode='import {Client} from "./dist/index.js"; new Client();'
+
+echo "test loading as commonJS..."
+if ! node -e "${cjsCode}" ; then
+  failed=1
+  echo 'Loading package as commomJS failed' >&2
+fi
+
+echo "test loading as ESM..."
+if ! node --input-type module -e "${esmCode}" ; then
+  failed=1
+  echo 'Loading package as ESM failed' >&2
+fi
+
+if [ $failed -eq 1 ] ; then exit 1 ; fi


### PR DESCRIPTION
packages that no longer support commonjs  use (currently, `retry-axios@3.x` and `query-string@8.x`) should never be installed (#1047). 

However, without a failing test, the dependabot PRs will just slip through, so we have to add a test that will fail when import/require of this package won't work.
