### PR TITLE
test: fix places/photo test

### DIFF
--- a/e2e/places/photo.test.ts
+++ b/e2e/places/photo.test.ts
@@ -15,13 +15,25 @@
  */
 
 import { placePhoto } from "../../src/places/photo";
+import { placeDetails } from "../../src/places/details";
 
 test("photo should return correct result", async () => {
+  const placeDetailsResponse = await placeDetails({
+    params: {
+      // The Museum of Modern Art, 11 W 53rd St, New York
+      place_id: "ChIJKxDbe_lYwokRVf__s8CPn-o",
+      key: process.env.GOOGLE_MAPS_API_KEY,
+      fields: ["place_id", "photo"],
+    },
+  });
+
+  const [photo] = placeDetailsResponse.data.result.photos;
+  const { photo_reference: photoreference } = photo;
+
   const params = {
-    photoreference:
-      "AZose0kqzNAxzQSLYC-kxAidG_FkCelqG6lXa-05yhbKfwfGd0Agu4YXSjvArtNEYLC8CiCvQb4uxQzfn2fZi2kzxeMBgtOHmbo0c8eqMx_YPVNRCjjPL_kA77NOWF5wOS2ub6ZQlM0G8XibN93burBky0JLCE5sf-C6gLVEG74yiPYoK8id",
-    maxwidth: 100,
-    maxheight: 100,
+    photoreference,
+    maxwidth: 1000,
+    maxheight: 1000,
     key: process.env.GOOGLE_MAPS_API_KEY,
   };
   const r = await placePhoto({ params: params, responseType: "arraybuffer" });

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,5 @@ module.exports = {
   transformIgnorePatterns: [
     "/node_modules/(?!(axios|retry-axios|query-string|decode-uri-component|split-on-first|filter-obj)/)",
   ],
-  collectCoverage: true,
   collectCoverageFrom: ["src/**/([a-zA-Z_]*).{js,ts}", "!**/*.test.{js,ts}"],
 };

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "docs": "rm -rf docs/ && typedoc src/index.ts",
     "prepack": "npm run build",
     "pretest": "npm run build",
-    "test": "jest ./src/* && npm run test:loading",
+    "test": "jest --runInBand --collectCoverage ./src/* && npm run test:loading",
     "test:loading": "./test-module-loading.sh",
-    "test:e2e": "jest ./e2e/*",
-    "test:all": "jest",
+    "test:e2e": "jest --runInBand ./e2e/*",
+    "test:all": "jest --runInBand",
     "format": "eslint . --fix",
     "lint": "eslint ."
   },


### PR DESCRIPTION
This should fix the failing tests observed in recent workflow-runs. 

The test for the Place Photos API was using a hardcoded `photoreference` which apparently is no longer valid. 
The updated test retrieves a photo reference via place details request, which should always produce valid results.

Also changed the way the tests are run. This includes specifying `--runInBand` via command line (avoid problems with serializing error-objects with cyclic structure) and only using `--collectCoverage` when running tests via npm when it's actually required.