### PR TITLE
fix(common): make DirectionsStep.steps an optional DirectionsStep[]

### DIFF
--- a/src/common.directionsstep.test.ts
+++ b/src/common.directionsstep.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression test for issue #1319.
+ *
+ * The Google Directions API only populates `steps[i].steps` (substeps) and
+ * `steps[i].transit_details` for transit travel mode. The previous typings
+ * declared both as required and, for `steps`, as a non-array
+ * `DirectionsStep`, which did not match the API response.
+ *
+ * Each block below is a compile-time assertion: if the typings regress,
+ * `tsc`/`ts-jest` will fail the build before any runtime assertion runs.
+ */
+
+import { Maneuver, TravelMode, VehicleType } from "./common";
+import type { DirectionsStep, TransitDetails } from "./common";
+
+const baseStep: DirectionsStep = {
+  html_instructions: "Head north-west",
+  distance: { value: 0, text: "" },
+  duration: { value: 0, text: "" },
+  start_location: { lat: 0, lng: 0 },
+  end_location: { lat: 0, lng: 0 },
+  maneuver: Maneuver.turn_left,
+  polyline: { points: "" },
+  travel_mode: TravelMode.driving,
+};
+
+const transitDetails: TransitDetails = {
+  arrival_stop: { name: "Innes Ave & Fitch St", location: { lat: 0, lng: 0 } },
+  departure_stop: { name: "24th St", location: { lat: 0, lng: 0 } },
+  arrival_time: { value: new Date(0), text: "", time_zone: "" },
+  departure_time: { value: new Date(0), text: "", time_zone: "" },
+  headsign: "Ocean Beach",
+  headway: 600,
+  num_stops: 5,
+  line: {
+    agencies: [{ name: "SFMTA", url: "", phone: "" }],
+    name: "N Judah",
+    short_name: "N",
+    color: "#0000FF",
+    url: "https://www.sfmta.com",
+    icon: "",
+    text_color: "#FFFFFF",
+    vehicle: {
+      name: "Light rail",
+      icon: "",
+      local_icon: "",
+      type: VehicleType.TRAM,
+    },
+  },
+};
+
+test("DirectionsStep.steps is an optional array of DirectionsStep", () => {
+  // Substeps are an array (compile-time check).
+  const transitStep: DirectionsStep = {
+    ...baseStep,
+    travel_mode: TravelMode.transit,
+    steps: [
+      {
+        ...baseStep,
+        html_instructions: "Walk to Innes Ave & Fitch St",
+      },
+    ],
+    // transit_details has a pinned type so a regression to a wrong element
+    // type would fail compilation, not just the runtime sanity check.
+    transit_details: transitDetails,
+  };
+
+  // The runtime field, when read, is `DirectionsStep[] | undefined`.
+  const substeps: DirectionsStep[] | undefined = transitStep.steps;
+  expect(Array.isArray(substeps) || substeps === undefined).toBe(true);
+});
+
+test("DirectionsStep does not require a steps field (non-transit steps)", () => {
+  // A step without a `steps` field is valid (compile-time check).
+  const drivingStep: DirectionsStep = baseStep;
+  expect(drivingStep.travel_mode).toBe(TravelMode.driving);
+});
+
+test("DirectionsStep.transit_details is optional (only present for transit)", () => {
+  // A step without `transit_details` is valid (compile-time check).
+  const drivingStep: DirectionsStep = baseStep;
+  expect(drivingStep.transit_details).toBeUndefined();
+
+  // The declared type of a present transit_details must be TransitDetails.
+  const transitStep: DirectionsStep = {
+    ...baseStep,
+    transit_details: transitDetails,
+  };
+  const td: TransitDetails | undefined = transitStep.transit_details;
+  expect(td && typeof td === "object" && "line" in td).toBe(true);
+});

--- a/src/common.ts
+++ b/src/common.ts
@@ -1100,9 +1100,9 @@ export interface DirectionsStep {
    * Substeps are only available when `travel_mode` is set to "transit".
    * The inner `steps` array is of the same type as `steps`.
    */
-  steps: DirectionsStep;
+  steps?: DirectionsStep[];
   /** contains transit specific information. This field is only returned with travel_mode is set to "transit". */
-  transit_details: TransitDetails;
+  transit_details?: TransitDetails;
   /** contains the type of travel mode used. */
   travel_mode: TravelMode;
 }


### PR DESCRIPTION
Fixes #1319

The `DirectionsStep` interface in `src/common.ts` previously declared `steps` and `transit_details` as required non-optional fields, and declared `steps` as a single `DirectionsStep` rather than an array.

This does not match the Google Directions API response:

* `steps[i].steps` is only populated for `travel_mode === "transit"` and is always returned as an array (see API docs: "If the directions include multiple modes of transportation, detailed directions will be provided for walking or driving steps in an inner `steps` array").
* `steps[i].transit_details` is only returned for `travel_mode === "transit"`.

This change:

* Types `steps` as the optional `DirectionsStep[]`.
* Marks `transit_details` optional as well.

Both changes were requested in #1319 and the prior (now-closed) attempt at PR #1389.

Added regression test: `src/common.directionsstep.test.ts` (compile-time type assertions + runtime sanity checks), including a pinned `TransitDetails`-typed transit step. All 72 unit tests pass with the fix; the new test fails to compile against the previous typings.

Local checks:
- `npm run build` (tsc): clean.
- `npx jest --runInBand ./src/`: 72/72 pass.
- `bash test-module-loading.sh`: cjs + esm loads succeed.

CLA: I will sign the Google Individual CLA when a maintainer approves.

Signed-off-by: simonyang08 <ppt5928@gmail.com>