### PR TITLE
fix: don't crash serializing an explicit null/undefined param value

### DIFF
--- a/src/serialize.test.ts
+++ b/src/serialize.test.ts
@@ -76,6 +76,27 @@ test("serializer should not mutate params", () => {
   expect(params.location).toBe(location);
 });
 
+test("serializer should not format an explicit null/undefined value, and should drop it from the query string", () => {
+  expect(
+    serializer(
+      { location: latLngToString },
+      "http://mock.url"
+    )({
+      radius: 50000,
+      location: undefined,
+    })
+  ).toBe("radius=50000");
+  expect(
+    serializer(
+      { location: latLngToString },
+      "http://mock.url"
+    )({
+      radius: 50000,
+      location: null,
+    })
+  ).toBe("radius=50000");
+});
+
 test("serializer should return pipe joined arrays by default", () => {
   expect(serializer({}, "http://mock.url")({ foo: ["b", "a", "r"] })).toBe(
     "foo=b|a|r"

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -125,7 +125,17 @@ export function serializer(
 
     for (const key of Object.keys(format)) {
       if (key in serializedParams) {
-        serializedParams[key] = format[key](serializedParams[key]);
+        // An explicit `null`/`undefined` (e.g. `{ location: undefined }`) means
+        // "not supplied", not "format this value" — several format functions
+        // (e.g. `latLngToString`) throw on it. Deleting the key rather than
+        // leaving it as-is also sidesteps `qs()`'s inconsistent handling of
+        // the two: it drops `undefined` from the query string by default but
+        // keeps `null` as a bare, value-less key.
+        if (serializedParams[key] == null) {
+          delete serializedParams[key];
+        } else {
+          serializedParams[key] = format[key](serializedParams[key]);
+        }
       }
     }
 


### PR DESCRIPTION
Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary) — no user-facing docs needed for this internal serialization fix

Fixes #1052 🦕

## What & why

`serializer()` called each key's format function unconditionally whenever the key existed on the params object, so `{ location: undefined }` — a common way to conditionally omit an optional field — reached `latLngToString` and threw `Cannot use 'in' operator to search for 'lat' in undefined`, instead of being treated as "not supplied". @usefulthink correctly identified the root cause in the issue thread.

## What changed

`src/serialize.ts` — in `serializer()`, a key whose value is `null`/`undefined` is now deleted from `serializedParams` before the format step, rather than being passed through to the format function.

I initially tried leaving the nullish value in place and letting `query-string`'s own `stringify` drop it, but that turned out to be inconsistent: `query-string` omits `undefined` from the output query string by default, but keeps `null` as a bare, value-less key (e.g. `location` with no `=`). Deleting the key outright avoids that mismatch and treats both the same way — as if the key were never supplied.

## How it was verified

- Added a test in `src/serialize.test.ts` covering both `location: undefined` and `location: null` against a formatted key, asserting the key is dropped entirely from the resulting query string.
- `npx jest src/` — 21/21 test suites, 70/70 tests passing.
- `npx tsc --noEmit` — clean.
- `npx eslint src/serialize.ts src/serialize.test.ts` — clean.
- The repo's `e2e/*` suite requires a live Google Maps API key and network access, unavailable in my environment — confirmed those failures are unrelated to this change (same failure mode before and after, purely network/API-key dependent).

## Note

I'll need to sign the Google Individual CLA before this can be merged, per CONTRIBUTING.md.